### PR TITLE
Add gitignore location generated from source

### DIFF
--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,13 @@ web/serve.sh
 web/dist/
 wild_kernel_comparison.md
 action_build_comparison.md
+
+# Gradle
+.gradle/
+build/
+app/.cxx/
+app/build/
+
+# Android Studio
+gradle-daemon-jvm.properties
+local.properties


### PR DESCRIPTION
When compile from Android Studio, some files and folder will auto-generated. This commit just don't commit this file to git.

<img width="305" height="581" alt="image" src="https://github.com/user-attachments/assets/a99ff578-d6a3-4e3e-8e4d-2b3ecb3a02b5" />
