### PR TITLE
fix: inject susfs_def.h in fs/proc/base.c for all android15-6.6 sublevels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1595,15 +1595,15 @@ jobs:
               fi
               if sub_in_range "$CURRENT_SUB" 98 127; then
                 apply_susfs_base_patch "Android 15 - 6.6 base.c" "a15-6.6/base.c.patch"
-                # 修复 6.6.98~6.6.127: fs/proc/base.c 头部 hunk 失配，导致 susfs_def.h 漏打
-                if grep -q 'AS_FLAGS_SUS_MAP\|susfs_is_current_proc_umounted\|SUSFS_IS_INODE_SUS_MAP\|SUSFS_IS_INODE_OPEN_REDIRECT' ./fs/proc/base.c && ! grep -qF 'susfs_def.h' ./fs/proc/base.c; then
-                  if ! grep -qF '#include <linux/dma-buf.h>' ./fs/proc/base.c; then
-                    sed -i '/#include <linux\/cpufreq_times.h>/a #include <linux\/dma-buf.h>' ./fs/proc/base.c
-                  fi
-                  sed -i '/#include <linux\/dma-buf.h>/a #endif' ./fs/proc/base.c
-                  sed -i '/#include <linux\/dma-buf.h>/a #include <linux\/susfs_def.h>' ./fs/proc/base.c
-                  sed -i '/#include <linux\/dma-buf.h>/a #if defined(CONFIG_KSU_SUSFS_SUS_MAP) || defined(CONFIG_KSU_SUSFS_OPEN_REDIRECT)' ./fs/proc/base.c
+              fi
+              # 修复 fs/proc/base.c 缺少 susfs_def.h (不限 sublevel，检测到宏调用但缺头文件时注入)
+              if grep -q 'AS_FLAGS_SUS_MAP\|susfs_is_current_proc_umounted\|SUSFS_IS_INODE_SUS_MAP\|SUSFS_IS_INODE_OPEN_REDIRECT' ./fs/proc/base.c && ! grep -qF 'susfs_def.h' ./fs/proc/base.c; then
+                if ! grep -qF '#include <linux/dma-buf.h>' ./fs/proc/base.c; then
+                  sed -i '/#include <linux\/cpufreq_times.h>/a #include <linux\/dma-buf.h>' ./fs/proc/base.c
                 fi
+                sed -i '/#include <linux\/dma-buf.h>/a #endif' ./fs/proc/base.c
+                sed -i '/#include <linux\/dma-buf.h>/a #include <linux\/susfs_def.h>' ./fs/proc/base.c
+                sed -i '/#include <linux\/dma-buf.h>/a #if defined(CONFIG_KSU_SUSFS_SUS_MAP) || defined(CONFIG_KSU_SUSFS_OPEN_REDIRECT)' ./fs/proc/base.c
               fi
               if sub_in_range "$CURRENT_SUB" 50 58; then
                 apply_susfs_optional_patch "Android 15 - 6.6 task_mmu.c" "a15-6.6/task_mmu.c.patch"


### PR DESCRIPTION
## Problem

Builds for android15-6.6 with sublevel < 98 (e.g. 6.6.89) fail with:

fs/proc/base.c: error: call to undeclared function 'SUSFS_IS_INODE_OPEN_REDIRECT'
fs/proc/base.c: error: call to undeclared function 'SUSFS_IS_INODE_SUS_MAP'

## Root cause

The SUSFS patch `50_add_susfs_in_gki-android15-6.6.patch` adds calls to
`SUSFS_IS_INODE_OPEN_REDIRECT` and `SUSFS_IS_INODE_SUS_MAP` in `fs/proc/base.c`
for all android15-6.6 sublevels. These macros are declared in `<linux/susfs_def.h>`.

The existing `susfs_def.h` injection in the workflow was gated behind
`sub_in_range "$CURRENT_SUB" 98 127`, so sublevels below 98 never received
the header fix — causing the compiler error above.

## Fix

The `apply_susfs_base_patch` call remains inside the `98–127` range (it is
a separate hunk-mismatch workaround specific to those sublevels).

The `susfs_def.h` injection is moved outside the range block and made
condition-based: it only fires when `SUSFS_IS_INODE_SUS_MAP` /
`SUSFS_IS_INODE_OPEN_REDIRECT` are present in `fs/proc/base.c` **and**
`susfs_def.h` is not yet included. This makes it safe for all sublevels
and idempotent (will not double-inject).