### PR TITLE
Adjust virtualization kABI patch application method.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1932,12 +1932,12 @@ jobs:
             local patch_file="$1"
             local name
             name="$(basename "$patch_file")"
-            if git apply --check "$patch_file" >/dev/null 2>&1; then
-              git apply "$patch_file"
+            if patch -p1 --forward --dry-run < "$patch_file" >/dev/null 2>&1; then
+              patch -p1 --forward < "$patch_file"
               echo "已应用虚拟化支持 patch: $name"
               return 0
             fi
-            if git apply --reverse --check "$patch_file" >/dev/null 2>&1; then
+            if patch -p1 --reverse --dry-run < "$patch_file" >/dev/null 2>&1; then
               echo "虚拟化支持 patch 已应用: $name"
               return 0
             fi


### PR DESCRIPTION
Adjust the virtualization kABI patch application method from `git apply` to `patch -p1 --forward`.

调整虚拟化 kABI 补丁的应用方式，将 `git apply --check && git apply` 改为 `patch -p1 --forward --dry-run` + `patch -p1 --forward`。


在小米 Pad 8 Pro 上，Droidspace 必须使用虚拟化 `345` 槽位补丁才能正常开机。

当前 workflow 对虚拟化 kABI 补丁使用 `git apply --check && git apply`，这个方式比较严格。当目标内核源码和补丁上下文存在轻微漂移时，即使补丁内容仍然可以正确匹配，也会直接应用失败。

实际失败场景中，`android15-6.6.77 + virtualization_support=345` 会卡在：

001.GKI-below-6.12-fix_sysvipc_kabi_3_4_5.patch

修改后能正常patch，编译成功内核，DroidSpace检查也正常通过

<img width="3200" height="2136" alt="Screenshot_2026-05-23-22-43-50-741_com droidspaces app" src="https://github.com/user-attachments/assets/c9437e41-3176-4a14-bc71-710f28f2b7b3" />


