### PR TITLE
Update build configuration in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
 
           # Dev 固定引用先完整复制 Stable 配置，后续只改这里的 *_DEV_REF 即可。
           OFFICIAL_DEV_REF="290609c945728fc93d85735918793567588103c1"
-          SUKISU_DEV_REF="c5af9eadac43b1f0b9751471be78e6eef681554b"
+          SUKISU_DEV_REF="aac170bcb86ce45516b3e2c0e2b32b57004b8f73"
           RESUKISU_DEV_REF="fb771414f249ab886c09f2cfcbbf91c4b4dab2d1"
 
           get_success_action_sha() {


### PR DESCRIPTION
This pull request updates the `SUKISU_DEV_REF` value in the GitHub Actions workflow configuration. This change ensures the development workflow references the latest commit for the `SUKISU` component.

- Workflow configuration:
  * [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L391-R391): Updated the `SUKISU_DEV_REF` to point to commit `aac170bcb86ce45516b3e2c0e2b32b57004b8f73` for the development build process.