### PR TITLE
fix(ci,app): drop magiskboot after SukiSU bootimg migration

### DIFF
--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -73,19 +73,6 @@ jobs:
           commit="$(git -C "$source_dir" rev-parse HEAD)"
           mkdir -p "$target_dir" "$jni_target_dir"
 
-          SOURCE_DIR="$source_dir" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          path = Path(os.environ["SOURCE_DIR"]) / "userspace/ksud/src/boot_patch.rs"
-          text = path.read_text()
-          old = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_path)\n                    .context(\"copy magiskboot failed\")?;\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          new = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                let magiskboot_bin = workdir.join(\"magiskboot.bin\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_bin)\n                    .context(\"copy magiskboot failed\")?;\n                #[cfg(unix)]\n                {\n                    use std::io::Write;\n                    let mut wrapper = std::fs::File::create(&magiskboot_path)?;\n                    wrapper.write_all(b\"#!/system/bin/sh\\nLINKER=/apex/com.android.runtime/bin/linker64\\n[ -x \\\\\\\"$LINKER\\\\\\\" ] || LINKER=/system/bin/linker64\\nexec \\\\\\\"$LINKER\\\\\\\" \\\\\\\"$0.bin\\\\\\\" \\\\\\\"$@\\\\\\\"\\n\")?;\n                    let _ = std::fs::set_permissions(&magiskboot_path, std::fs::Permissions::from_mode(0o755));\n                    let _ = std::fs::set_permissions(&magiskboot_bin, std::fs::Permissions::from_mode(0o755));\n                }\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          if old not in text:
-              raise SystemExit("failed to find magiskboot injection block in boot_patch.rs")
-          path.write_text(text.replace(old, new, 1))
-          PY
-
           setup_rust_build() {
             local triple="$1"
             local android_sdk_level="$2"
@@ -179,18 +166,6 @@ jobs:
               --manifest-path "$source_dir/Cargo.toml"
           }
 
-          magiskboot_url_for_abi() {
-            case "$1" in
-              arm64-v8a) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/arm64-v8a/libmagiskboot.so" ;;
-              x86_64) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/x86_64/libmagiskboot.so" ;;
-              armeabi-v7a) printf '%s\n' "" ;;
-              *)
-                echo "::error::Unsupported magiskboot ABI: $1"
-                return 1
-                ;;
-            esac
-          }
-
           {
             echo "source_repo=$repo_url"
             echo "ref=$SUKISU_ULTRA_REF"
@@ -225,13 +200,6 @@ jobs:
               exit 1
             fi
             install -Dm755 "$ksuinit_binary" "$bin_dir/ksuinit"
-            magiskboot_url="$(magiskboot_url_for_abi "$abi")"
-            if [ -n "$magiskboot_url" ]; then
-              curl -fsSL "$magiskboot_url" -o "$bin_dir/magiskboot"
-              chmod 755 "$bin_dir/magiskboot"
-            else
-              echo "warning.$abi=magiskboot_missing_upstream" >> "$target_dir/source.properties"
-            fi
             setup_rust_build "$triple" 26
             cargo build \
               --target "$triple" \
@@ -275,7 +243,7 @@ jobs:
             echo "- Commit: $commit"
             echo "- ABIs: $SUKISU_KSUD_ABIS"
             echo "- Embedded ksuinit: aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
-            echo "- Embedded magiskboot: arm64-v8a, x86_64"
+            echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Bundle ABK LKM artifacts

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - "app/**"
+      - "app_dev/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle/**"
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - "app/**"
+      - "app_dev/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle/**"
@@ -70,19 +72,6 @@ jobs:
           git clone --depth 1 --branch "$SUKISU_ULTRA_REF" "$SUKISU_ULTRA_REPO" "$source_dir"
           commit="$(git -C "$source_dir" rev-parse HEAD)"
           mkdir -p "$target_dir" "$jni_target_dir"
-
-          SOURCE_DIR="$source_dir" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          path = Path(os.environ["SOURCE_DIR"]) / "userspace/ksud/src/boot_patch.rs"
-          text = path.read_text()
-          old = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_path)\n                    .context(\"copy magiskboot failed\")?;\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          new = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                let magiskboot_bin = workdir.join(\"magiskboot.bin\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_bin)\n                    .context(\"copy magiskboot failed\")?;\n                #[cfg(unix)]\n                {\n                    use std::io::Write;\n                    let mut wrapper = std::fs::File::create(&magiskboot_path)?;\n                    wrapper.write_all(b\"#!/system/bin/sh\\nLINKER=/apex/com.android.runtime/bin/linker64\\n[ -x \\\\\\\"$LINKER\\\\\\\" ] || LINKER=/system/bin/linker64\\nexec \\\\\\\"$LINKER\\\\\\\" \\\\\\\"$0.bin\\\\\\\" \\\\\\\"$@\\\\\\\"\\n\")?;\n                    let _ = std::fs::set_permissions(&magiskboot_path, std::fs::Permissions::from_mode(0o755));\n                    let _ = std::fs::set_permissions(&magiskboot_bin, std::fs::Permissions::from_mode(0o755));\n                }\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          if old not in text:
-              raise SystemExit("failed to find magiskboot injection block in boot_patch.rs")
-          path.write_text(text.replace(old, new, 1))
-          PY
 
           setup_rust_build() {
             local triple="$1"
@@ -177,18 +166,6 @@ jobs:
               --manifest-path "$source_dir/Cargo.toml"
           }
 
-          magiskboot_url_for_abi() {
-            case "$1" in
-              arm64-v8a) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/arm64-v8a/libmagiskboot.so" ;;
-              x86_64) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/x86_64/libmagiskboot.so" ;;
-              armeabi-v7a) printf '%s\n' "" ;;
-              *)
-                echo "::error::Unsupported magiskboot ABI: $1"
-                return 1
-                ;;
-            esac
-          }
-
           {
             echo "source_repo=$repo_url"
             echo "ref=$SUKISU_ULTRA_REF"
@@ -223,13 +200,6 @@ jobs:
               exit 1
             fi
             install -Dm755 "$ksuinit_binary" "$bin_dir/ksuinit"
-            magiskboot_url="$(magiskboot_url_for_abi "$abi")"
-            if [ -n "$magiskboot_url" ]; then
-              curl -fsSL "$magiskboot_url" -o "$bin_dir/magiskboot"
-              chmod 755 "$bin_dir/magiskboot"
-            else
-              echo "warning.$abi=magiskboot_missing_upstream" >> "$target_dir/source.properties"
-            fi
             setup_rust_build "$triple" 26
             cargo build \
               --target "$triple" \
@@ -273,7 +243,7 @@ jobs:
             echo "- Commit: $commit"
             echo "- ABIs: $SUKISU_KSUD_ABIS"
             echo "- Embedded ksuinit: aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
-            echo "- Embedded magiskboot: arm64-v8a, x86_64"
+            echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Bundle ABK LKM artifacts

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -51,7 +51,7 @@ This document records the open source projects, embedded code, generated binarie
 
 ## APK-Bundled SukiSU Components
 
-The APK build workflows compile `userspace/ksud` from `SukiSU-Ultra/SukiSU-Ultra` and download `libmagiskboot.so` from that upstream manager tree for supported ABIs. Prebuilt `ksud` binaries are not committed to this repository. The pinned upstream ref is declared in `.github/workflows/build-abk-app.yml` and `.github/workflows/build-abk-app-dev.yml`.
+The APK build workflows compile `userspace/ksud` from `SukiSU-Ultra/SukiSU-Ultra` for supported ABIs. Upstream ksud patches boot images with the in-process `android_bootimg` crate and no longer ships or requires `libmagiskboot.so`. Prebuilt `ksud` binaries are not committed to this repository. The upstream ref is declared in `.github/workflows/build-abk-app.yml` and `.github/workflows/build-abk-app-dev.yml`.
 
 ## Android / Gradle Dependencies
 

--- a/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
@@ -184,9 +184,6 @@ fun AbkRootPatchScreen(
     val userlandKsudPath by produceState<String?>(initialValue = null, context) {
         value = withContext(Dispatchers.IO) { RootUtils.resolveUserlandKsudPath(context) }
     }
-    val userlandMagiskbootPath by produceState<String?>(initialValue = null, context) {
-        value = withContext(Dispatchers.IO) { RootUtils.resolveUserlandMagiskbootPath(context) }
-    }
     val hasLocalLkm = selectedLocalLkmPath.isNotBlank()
     val activeLkmLabel = selectedLocalLkmName.takeIf { it.isNotBlank() }
         ?: selectedAsset?.let { "${it.variantLabel} · ${it.kmi}" }
@@ -194,11 +191,10 @@ fun AbkRootPatchScreen(
     val hasLkmSource = hasLocalLkm || selectedAsset != null
     val showRootInstallModes = rootGranted
     val hasUserlandKsud = userlandKsudPath != null
-    val hasUserlandMagiskboot = userlandMagiskbootPath != null
     val canPatchSelectedFile = selectedBootPath.isNotBlank() &&
         hasLkmSource &&
         !running &&
-        (rootGranted || (hasUserlandKsud && hasUserlandMagiskboot))
+        (rootGranted || hasUserlandKsud)
     val canDirectInstall = rootGranted && hasLkmSource && !running
     val canFlashAnyKernel3 = rootGranted && selectedAnyKernelPath.isNotBlank() && !running
     val canProceed = when (selectedMode) {
@@ -788,11 +784,8 @@ fun AbkRootPatchScreen(
             if (!hasLkmSource && selectedMode != LkmPatchInstallMode.AnyKernel3) {
                 InlineWarning(stringResource(R.string.root_patch_warn_no_lkm))
             }
-            if (selectedMode == LkmPatchInstallMode.SelectFile && !rootGranted) {
-                when {
-                    !hasUserlandKsud -> InlineWarning(stringResource(R.string.root_patch_warn_no_ksud))
-                    !hasUserlandMagiskboot -> InlineWarning(stringResource(R.string.root_patch_warn_no_magiskboot))
-                }
+            if (selectedMode == LkmPatchInstallMode.SelectFile && !rootGranted && !hasUserlandKsud) {
+                InlineWarning(stringResource(R.string.root_patch_warn_no_ksud))
             }
 
             Button(

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -1675,7 +1675,7 @@ private fun openSourceNoticeGroups(): List<OpenSourceNoticeGroup> = listOf(
             OpenSourceNotice("Xiaomichael/kernel_manifest", "Upstream repository license / no SPDX detected", "OnePlus manifest branch source", "https://github.com/Xiaomichael/kernel_manifest"),
             OpenSourceNotice("Xiaomichael/kernel_patches", "Upstream repository license / no SPDX detected", "OnePlus patch source", "https://github.com/Xiaomichael/kernel_patches"),
             OpenSourceNotice("KernelSU", "GPL-3.0", "workflow setup.sh source", "https://github.com/tiann/KernelSU"),
-            OpenSourceNotice("SukiSU Ultra", "GPL-3.0", "kernel setup, ksud, libmagiskboot source", "https://github.com/SukiSU-Ultra/SukiSU-Ultra"),
+            OpenSourceNotice("SukiSU Ultra", "GPL-3.0", "kernel setup, ksud, android_bootimg", "https://github.com/SukiSU-Ultra/SukiSU-Ultra"),
             OpenSourceNotice("ReSukiSU", "GPL-3.0", "workflow setup.sh source", "https://github.com/ReSukiSU/ReSukiSU"),
             OpenSourceNotice("SUSFS", "GPL-2.0", "kernel patches and module integration", "https://gitlab.com/simonpunk/susfs4ksu"),
             OpenSourceNotice("ShirkNeko/susfs4ksu", "GPL-2.0", "GitHub mirror / patch source", "https://github.com/ShirkNeko/susfs4ksu"),

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -398,8 +398,6 @@ object RootUtils {
     fun resolveUserlandKsudPath(context: Context): String? =
         prepareBundledKsudPath(context) ?: embeddedKsudPath(context)
 
-    fun resolveUserlandMagiskbootPath(context: Context): String? = embeddedMagiskbootPath(context)
-
     fun patchAbkLkmBootImage(
         context: Context,
         bootImagePath: String?,
@@ -1594,13 +1592,6 @@ object RootUtils {
     private fun buildKsudShellCommand(ksudPath: String, args: List<String>): String =
         buildShellCommand(buildKsudCommand(ksudPath, args))
 
-    private fun embeddedMagiskbootPath(context: Context? = appContext): String? {
-        val safeContext = context ?: return null
-        return File(safeContext.applicationInfo.nativeLibraryDir, "libmagiskboot.so")
-            .takeIf { it.isFile }
-            ?.absolutePath
-    }
-
     private fun runEmbeddedKsudWithRoot(
         context: Context,
         args: List<String>,
@@ -1692,10 +1683,6 @@ object RootUtils {
     ): List<String> {
         return buildList {
             add("boot-patch")
-            embeddedMagiskbootPath(context)?.let { magiskboot ->
-                add("--magiskboot")
-                add(magiskboot)
-            }
             if (bootImage != null) {
                 add("--boot")
                 add(bootImage.absolutePath)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -838,7 +838,6 @@
     <string name="root_patch_enable_adb_debug_desc">Force USB debugging and disable adb authentication. Enable only when needed.</string>
     <string name="root_patch_warn_no_lkm">No bundled LKM matches the current variant and KMI. Select a local .ko file.</string>
     <string name="root_patch_warn_no_ksud">This APK does not include an executable bundled SukiSU-Ultra ksud, so it can not patch boot.img without root. Use an APK with bundled ksud, or grant root and continue.</string>
-    <string name="root_patch_warn_no_magiskboot">This APK does not include an executable bundled magiskboot, so it can not unpack boot.img without root. Use an APK with bundled magiskboot, or grant root and continue.</string>
     <string name="root_patch_processing">Processing</string>
     <string name="root_patch_next">Next</string>
     <string name="root_patch_result">Patch result</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -815,7 +815,6 @@
     <string name="root_patch_enable_adb_debug_desc">Принудительно разрешить USB-отладку и отключить аутентификацию adb. Включайте только при необходимости.</string>
     <string name="root_patch_warn_no_lkm">Для текущего варианта и KMI нет встроенного LKM. Выберите локальный .ko-файл.</string>
     <string name="root_patch_warn_no_ksud">В этот APK не встроен исполняемый SukiSU-Ultra ksud, поэтому пропатчить boot.img без root нельзя. Используйте APK со встроенным ksud или выдайте root.</string>
-    <string name="root_patch_warn_no_magiskboot">В этот APK не встроен исполняемый magiskboot, поэтому распаковать boot.img без root нельзя. Используйте APK со встроенным magiskboot или выдайте root.</string>
     <string name="root_patch_processing">Обработка</string>
     <string name="root_patch_next">Далее</string>
     <string name="root_patch_result">Результат патча</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -838,7 +838,6 @@
     <string name="root_patch_enable_adb_debug_desc">强制允许 USB 调试并取消 adb 认证，非必要请勿开启。</string>
     <string name="root_patch_warn_no_lkm">当前变体和 KMI 没有内置 LKM，请选择本地 .ko 文件。</string>
     <string name="root_patch_warn_no_ksud">当前 APK 未包含可执行的内置 SukiSU-Ultra ksud，无法无 Root 修补 boot.img。请使用带内置 ksud 的 APK，或授予 Root 后继续。</string>
-    <string name="root_patch_warn_no_magiskboot">当前 APK 未包含可执行的内置 magiskboot，无法无 Root 解包 boot.img。请使用带内置 magiskboot 的 APK，或授予 Root 后继续。</string>
     <string name="root_patch_processing">处理中</string>
     <string name="root_patch_next">下一步</string>
     <string name="root_patch_result">修补结果</string>


### PR DESCRIPTION

---
## Problem
CI fails while bundling ksud (`curl -fsSL`):
```text
curl: (22) The requested URL returned error: 404
https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/arm64-v8a/libmagiskboot.so
```
*(Verified: HTTP 404 as of 2026-05-26.)*
ABK also ran a Python patch on `userspace/ksud/src/boot_patch.rs` that replaced an upstream magiskboot copy block with a shell wrapper. That target block was removed upstream together with magiskboot, so the patch would fail with `failed to find magiskboot injection block in boot_patch.rs`.
---
## Changes
### CI (`.github/workflows/build-abk-app.yml`, `build-abk-app-dev.yml`)
Removed from both workflows:
- Python patch of `boot_patch.rs`
- `magiskboot_url_for_abi()` helper
- `curl` of `libmagiskboot.so` into `userspace/ksud/bin/<abi>/magiskboot` (build-time ksud asset)
Updated build summary line to: *magiskboot removed upstream (ksud uses bootimg crate)*.
Also adds `app_dev/**` to **`build-abk-app.yml`** path filters (upstream `dev` already had this in the dev workflow; release workflow did not).
### App
| File | Change |
|------|--------|
| `RootUtils.kt` | Removed `embeddedMagiskbootPath`, `resolveUserlandMagiskbootPath`, and optional `--magiskboot` args |
| `AbkRootPatchScreen.kt` | Userland boot patch requires bundled `ksud` only (no magiskboot gate) |
| `SettingsScreen.kt` | OSS notice: `android_bootimg` instead of libmagiskboot |
| `THIRD_PARTY_NOTICES.md` | Documents ksud + `android_bootimg`; no libmagiskboot download |
| `app/src/main/res/values/strings.xml`, `values-en`, `values-ru` | Removed `root_patch_warn_no_magiskboot` |
**Diff:** 9 files · **−94 / +9** lines (single commit on branch)
---
## Before → After
| | Before | After |
|---|--------|-------|
| CI ksud build | Downloads missing `libmagiskboot.so` into ksud asset dir | Builds ksud without external magiskboot |
| App `boot-patch` | Could append `--magiskboot <path>` if `libmagiskboot.so` was present | `ksud boot-patch` only (bootimg crate inside ksud) |
| Userland UX | Required ksud **and** magiskboot for non-root patch | Requires ksud only |
> CI has always installed only `libksud.so` into `app/build/generated/abk-jniLibs/main`; magiskboot was a **compile-time ksud asset**, not a separate APK native library.
---