### PR TITLE
Ci/abk app build cache

### DIFF
--- a/.github/actions/prepare-abk-app-inputs/action.yml
+++ b/.github/actions/prepare-abk-app-inputs/action.yml
@@ -1,0 +1,69 @@
+name: Prepare ABK app inputs
+description: Resolve SukiSU-Ultra and ABK LKM SHAs for CI cache keys
+outputs:
+  sukisu_commit:
+    description: Resolved commit for SUKISU_ULTRA_REF
+    value: ${{ steps.resolve.outputs.sukisu_commit }}
+  lkm_head_sha:
+    description: head_sha of latest successful ABK_control_module lkm.yml run
+    value: ${{ steps.resolve.outputs.lkm_head_sha }}
+  workflow_digest:
+    description: Hash of workflow and ksud build logic inputs
+    value: ${{ steps.resolve.outputs.workflow_digest }}
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        SUKISU_ULTRA_REPO: ${{ env.SUKISU_ULTRA_REPO }}
+        SUKISU_ULTRA_REF: ${{ env.SUKISU_ULTRA_REF }}
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${SUKISU_ULTRA_REPO:-}" ] || [ -z "${SUKISU_ULTRA_REF:-}" ]; then
+          echo "::error::SUKISU_ULTRA_REPO and SUKISU_ULTRA_REF must be set on the job"
+          exit 1
+        fi
+
+        sukisu_commit="$(git ls-remote "$SUKISU_ULTRA_REPO" "refs/heads/${SUKISU_ULTRA_REF}" 2>/dev/null | awk '{print $1}' || true)"
+        if [ -z "$sukisu_commit" ]; then
+          sukisu_commit="$(git ls-remote "$SUKISU_ULTRA_REPO" "$SUKISU_ULTRA_REF" | awk '{print $1}')"
+        fi
+        if [ -z "$sukisu_commit" ]; then
+          echo "::error::Could not resolve SukiSU commit for ref ${SUKISU_ULTRA_REF}"
+          exit 1
+        fi
+
+        repo="xingguangcuican6666/ABK_control_module"
+        workflow="lkm.yml"
+        api_url="https://api.github.com/repos/${repo}/actions/workflows/${workflow}/runs?status=success&per_page=1"
+        runs_json="$(curl -fsSL \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          "$api_url")"
+        lkm_head_sha="$(printf '%s' "$runs_json" | jq -r '.workflow_runs[0].head_sha // empty')"
+        if [ -z "$lkm_head_sha" ]; then
+          echo "::error::No successful LKM workflow run found for ${repo}"
+          exit 1
+        fi
+
+        workflow_digest="$(
+          {
+            [ -f .github/workflows/build-abk-app.yml ] && sha256sum .github/workflows/build-abk-app.yml
+            [ -f .github/workflows/build-abk-app-dev.yml ] && sha256sum .github/workflows/build-abk-app-dev.yml
+            [ -f .github/actions/prepare-abk-app-inputs/action.yml ] && sha256sum .github/actions/prepare-abk-app-inputs/action.yml
+          } | sha256sum | awk '{print $1}'
+        )"
+
+        echo "sukisu_commit=$sukisu_commit" >> "$GITHUB_OUTPUT"
+        echo "lkm_head_sha=$lkm_head_sha" >> "$GITHUB_OUTPUT"
+        echo "workflow_digest=$workflow_digest" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Resolved ABK app inputs"
+          echo "- sukisu_commit: \`$sukisu_commit\`"
+          echo "- lkm_head_sha: \`$lkm_head_sha\`"
+          echo "- workflow_digest: \`$workflow_digest\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/prepare-abk-app-inputs/action.yml
+++ b/.github/actions/prepare-abk-app-inputs/action.yml
@@ -10,6 +10,9 @@ outputs:
   workflow_digest:
     description: Hash of workflow and ksud build logic inputs
     value: ${{ steps.resolve.outputs.workflow_digest }}
+  ksud_abis_key:
+    description: SUKISU_KSUD_ABIS with commas replaced for actions/cache keys
+    value: ${{ steps.resolve.outputs.ksud_abis_key }}
 runs:
   using: composite
   steps:
@@ -18,6 +21,7 @@ runs:
       env:
         SUKISU_ULTRA_REPO: ${{ env.SUKISU_ULTRA_REPO }}
         SUKISU_ULTRA_REF: ${{ env.SUKISU_ULTRA_REF }}
+        SUKISU_KSUD_ABIS: ${{ env.SUKISU_KSUD_ABIS }}
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
@@ -57,9 +61,13 @@ runs:
           } | sha256sum | awk '{print $1}'
         )"
 
+        ksud_abis_key="${SUKISU_KSUD_ABIS:-arm64-v8a,armeabi-v7a,x86_64}"
+        ksud_abis_key="${ksud_abis_key//,/-}"
+
         echo "sukisu_commit=$sukisu_commit" >> "$GITHUB_OUTPUT"
         echo "lkm_head_sha=$lkm_head_sha" >> "$GITHUB_OUTPUT"
         echo "workflow_digest=$workflow_digest" >> "$GITHUB_OUTPUT"
+        echo "ksud_abis_key=$ksud_abis_key" >> "$GITHUB_OUTPUT"
 
         {
           echo "### Resolved ABK app inputs"

--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -10,6 +10,7 @@ on:
       - "settings.gradle.kts"
       - "gradle/**"
       - ".github/workflows/build-abk-app-dev.yml"
+      - ".github/actions/prepare-abk-app-inputs/**"
   pull_request:
     paths:
       - "app/**"
@@ -18,6 +19,7 @@ on:
       - "settings.gradle.kts"
       - "gradle/**"
       - ".github/workflows/build-abk-app-dev.yml"
+      - ".github/actions/prepare-abk-app-inputs/**"
 
 jobs:
   build:
@@ -43,20 +45,80 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Cache Android SDK packages
+        id: sdk-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+            ${{ env.ANDROID_HOME }}/build-tools/37.0.0
+            ${{ env.ANDROID_HOME }}/platforms/android-37
+            ${{ env.ANDROID_HOME }}/cmake/3.22.1
+          key: abk-app-sdk-v1-linux-ndk28.2-bt37.0-p37
+          restore-keys: abk-app-sdk-v1-linux-
+
       - name: Install Android SDK packages
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
         run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "9.3.1"
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
 
+      - name: Prepare ABK app inputs
+        id: abk-inputs
+        uses: ./.github/actions/prepare-abk-app-inputs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: abk-cargo-registry-v1-linux
+          restore-keys: abk-cargo-registry-v1-
+
+      - name: Cache ksud outputs
+        id: ksud-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/build/generated/abk-assets/main
+            app/build/generated/abk-jniLibs/main
+          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ env.SUKISU_KSUD_ABIS }}-${{ steps.abk-inputs.outputs.workflow_digest }}
+
+      - name: Verify ksud cache
+        id: ksud-verify
+        run: |
+          set -euo pipefail
+          expected="${{ steps.abk-inputs.outputs.sukisu_commit }}"
+          props="app/build/generated/abk-assets/main/ksud/source.properties"
+          if [ "${{ steps.ksud-cache.outputs.cache-hit }}" != "true" ] || [ ! -f "$props" ]; then
+            echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "ksud cache: miss"
+            exit 0
+          fi
+          actual="$(grep '^commit=' "$props" | cut -d= -f2- | tr -d '\r')"
+          if [ "$actual" != "$expected" ]; then
+            echo "ksud cache: stale (expected=$expected actual=$actual)"
+            rm -rf app/build/generated/abk-assets/main app/build/generated/abk-jniLibs/main
+            echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ksud cache: hit (commit=$actual)"
+            echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build bundled SukiSU-Ultra ksud assets
+        if: steps.ksud-verify.outputs.needs_rebuild == 'true'
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: |
@@ -246,7 +308,37 @@ jobs:
             echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Cache LKM assets
+        id: lkm-cache
+        uses: actions/cache@v4
+        with:
+          path: app/src/main/assets/abk_lkm
+          key: abk-lkm-v1-${{ steps.abk-inputs.outputs.lkm_head_sha }}
+
+      - name: Verify LKM cache
+        id: lkm-verify
+        run: |
+          set -euo pipefail
+          expected="${{ steps.abk-inputs.outputs.lkm_head_sha }}"
+          props="app/src/main/assets/abk_lkm/source.properties"
+          if [ "${{ steps.lkm-cache.outputs.cache-hit }}" != "true" ] || [ ! -f "$props" ]; then
+            echo "needs_rebundle=true" >> "$GITHUB_OUTPUT"
+            echo "lkm cache: miss"
+            exit 0
+          fi
+          actual="$(grep '^head_sha=' "$props" | cut -d= -f2- | tr -d '\r')"
+          if [ "$actual" != "$expected" ]; then
+            echo "lkm cache: stale (expected=$expected actual=$actual)"
+            rm -rf app/src/main/assets/abk_lkm
+            mkdir -p app/src/main/assets/abk_lkm
+            echo "needs_rebundle=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "lkm cache: hit (head_sha=$actual)"
+            echo "needs_rebundle=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bundle ABK LKM artifacts
+        if: steps.lkm-verify.outputs.needs_rebundle == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -94,7 +94,7 @@ jobs:
           path: |
             app/build/generated/abk-assets/main
             app/build/generated/abk-jniLibs/main
-          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ env.SUKISU_KSUD_ABIS }}-${{ steps.abk-inputs.outputs.workflow_digest }}
+          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ steps.abk-inputs.outputs.ksud_abis_key }}-${{ steps.abk-inputs.outputs.workflow_digest }}
 
       - name: Verify ksud cache
         id: ksud-verify

--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -45,20 +45,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Cache Android SDK packages
-        id: sdk-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
-            ${{ env.ANDROID_HOME }}/build-tools/37.0.0
-            ${{ env.ANDROID_HOME }}/platforms/android-37
-            ${{ env.ANDROID_HOME }}/cmake/3.22.1
-          key: abk-app-sdk-v1-linux-ndk28.2-bt37.0-p37
-          restore-keys: abk-app-sdk-v1-linux-
-
       - name: Install Android SDK packages
-        if: steps.sdk-cache.outputs.cache-hit != 'true'
         run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Set up Gradle

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -10,6 +10,7 @@ on:
       - "settings.gradle.kts"
       - "gradle/**"
       - ".github/workflows/build-abk-app.yml"
+      - ".github/actions/prepare-abk-app-inputs/**"
   pull_request:
     paths:
       - "app/**"
@@ -18,6 +19,7 @@ on:
       - "settings.gradle.kts"
       - "gradle/**"
       - ".github/workflows/build-abk-app.yml"
+      - ".github/actions/prepare-abk-app-inputs/**"
 
 jobs:
   build:
@@ -43,20 +45,80 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Cache Android SDK packages
+        id: sdk-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+            ${{ env.ANDROID_HOME }}/build-tools/37.0.0
+            ${{ env.ANDROID_HOME }}/platforms/android-37
+            ${{ env.ANDROID_HOME }}/cmake/3.22.1
+          key: abk-app-sdk-v1-linux-ndk28.2-bt37.0-p37
+          restore-keys: abk-app-sdk-v1-linux-
+
       - name: Install Android SDK packages
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
         run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "9.3.1"
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
 
+      - name: Prepare ABK app inputs
+        id: abk-inputs
+        uses: ./.github/actions/prepare-abk-app-inputs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: abk-cargo-registry-v1-linux
+          restore-keys: abk-cargo-registry-v1-
+
+      - name: Cache ksud outputs
+        id: ksud-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/build/generated/abk-assets/main
+            app/build/generated/abk-jniLibs/main
+          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ env.SUKISU_KSUD_ABIS }}-${{ steps.abk-inputs.outputs.workflow_digest }}
+
+      - name: Verify ksud cache
+        id: ksud-verify
+        run: |
+          set -euo pipefail
+          expected="${{ steps.abk-inputs.outputs.sukisu_commit }}"
+          props="app/build/generated/abk-assets/main/ksud/source.properties"
+          if [ "${{ steps.ksud-cache.outputs.cache-hit }}" != "true" ] || [ ! -f "$props" ]; then
+            echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "ksud cache: miss"
+            exit 0
+          fi
+          actual="$(grep '^commit=' "$props" | cut -d= -f2- | tr -d '\r')"
+          if [ "$actual" != "$expected" ]; then
+            echo "ksud cache: stale (expected=$expected actual=$actual)"
+            rm -rf app/build/generated/abk-assets/main app/build/generated/abk-jniLibs/main
+            echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ksud cache: hit (commit=$actual)"
+            echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build bundled SukiSU-Ultra ksud assets
+        if: steps.ksud-verify.outputs.needs_rebuild == 'true'
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: |
@@ -246,7 +308,37 @@ jobs:
             echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Cache LKM assets
+        id: lkm-cache
+        uses: actions/cache@v4
+        with:
+          path: app/src/main/assets/abk_lkm
+          key: abk-lkm-v1-${{ steps.abk-inputs.outputs.lkm_head_sha }}
+
+      - name: Verify LKM cache
+        id: lkm-verify
+        run: |
+          set -euo pipefail
+          expected="${{ steps.abk-inputs.outputs.lkm_head_sha }}"
+          props="app/src/main/assets/abk_lkm/source.properties"
+          if [ "${{ steps.lkm-cache.outputs.cache-hit }}" != "true" ] || [ ! -f "$props" ]; then
+            echo "needs_rebundle=true" >> "$GITHUB_OUTPUT"
+            echo "lkm cache: miss"
+            exit 0
+          fi
+          actual="$(grep '^head_sha=' "$props" | cut -d= -f2- | tr -d '\r')"
+          if [ "$actual" != "$expected" ]; then
+            echo "lkm cache: stale (expected=$expected actual=$actual)"
+            rm -rf app/src/main/assets/abk_lkm
+            mkdir -p app/src/main/assets/abk_lkm
+            echo "needs_rebundle=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "lkm cache: hit (head_sha=$actual)"
+            echo "needs_rebundle=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bundle ABK LKM artifacts
+        if: steps.lkm-verify.outputs.needs_rebundle == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -94,7 +94,7 @@ jobs:
           path: |
             app/build/generated/abk-assets/main
             app/build/generated/abk-jniLibs/main
-          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ env.SUKISU_KSUD_ABIS }}-${{ steps.abk-inputs.outputs.workflow_digest }}
+          key: abk-ksud-v1-${{ steps.abk-inputs.outputs.sukisu_commit }}-${{ steps.abk-inputs.outputs.ksud_abis_key }}-${{ steps.abk-inputs.outputs.workflow_digest }}
 
       - name: Verify ksud cache
         id: ksud-verify

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -45,20 +45,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Cache Android SDK packages
-        id: sdk-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
-            ${{ env.ANDROID_HOME }}/build-tools/37.0.0
-            ${{ env.ANDROID_HOME }}/platforms/android-37
-            ${{ env.ANDROID_HOME }}/cmake/3.22.1
-          key: abk-app-sdk-v1-linux-ndk28.2-bt37.0-p37
-          restore-keys: abk-app-sdk-v1-linux-
-
       - name: Install Android SDK packages
-        if: steps.sdk-cache.outputs.cache-hit != 'true'
         run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Set up Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true


### PR DESCRIPTION
# Speed up ABK App CI with layered GitHub Actions caches

## Summary

This PR adds **content-addressed caching** to the `Build ABK App` and `Build ABK App Dev` workflows. Repeat runs with unchanged upstream inputs (SukiSU-Ultra `ksud`, ABK LKM artifacts) skip the heaviest steps while producing the **same APK outputs** as before.

Measured on GitHub-hosted `ubuntu-latest`:

| Scenario | Before | After (warm cache) |
|----------|--------|---------------------|
| Typical push changing only `app/**` | ~11 min | **~6 min** |
| First run / upstream changed | ~11–13 min* | Similar (populates caches) |

\*First run after enabling caches can be longer due to cache upload; SDK system-path cache was **removed** after it failed to restore reliably.

---

## Problem

Both app workflows rebuild the same expensive artifacts on every run:

1. **Rust `ksud` + `ksuinit`** for three ABIs (~4+ min)
2. **Download & bundle LKM** `.ko` files from `ABK_control_module`
3. **Gradle** debug + release (unchanged in scope, but no build cache tuning)

There was no `actions/cache` usage for app workflows (unlike kernel `build.yml` with ccache).

---

## Solution

### Architecture

```
Every run
  └─ Resolve upstream SHAs (always)
       ├─ sukisu_commit  ← git ls-remote (SukiSU-Ultra @ SUKISU_ULTRA_REF)
       └─ lkm_head_sha    ← GitHub API (latest success lkm.yml)

Restore caches → Verify source.properties → Rebuild only stale layers → Gradle
```

Prod and dev workflows **share** ksud/LKM cache keys (identical upstream inputs; dev patch runs only before Gradle).

### New composite action

**`.github/actions/prepare-abk-app-inputs`**

| Output | Used for |
|--------|----------|
| `sukisu_commit` | ksud cache key + verify |
| `lkm_head_sha` | LKM cache key + verify |
| `workflow_digest` | ksud cache key (hash of app workflow YAML + action) |
| `ksud_abis_key` | ksud cache key (`arm64-v8a-armeabi-v7a-x86_64`, no commas) |

### Cache layers

| Layer | Key | Invalidates when |
|-------|-----|------------------|
| **ksud outputs** | `abk-ksud-v1-{commit}-{abis}-{digest}` | SukiSU moves, ABI list changes, workflow/action changes |
| **LKM assets** | `abk-lkm-v1-{head_sha}` | New successful `lkm.yml` run |
| **Cargo registry** | `abk-cargo-registry-v1-linux` | Rarely (shared; speeds ksud rebuild on SukiSU bump) |
| **Gradle** | `setup-gradle@v4` build cache | Lockfiles / project config (automatic) |

**Not cached:** Android SDK under `/usr/local/lib/android/sdk` — restore failed with `tar: Cannot utime/chmod` on hosted runners; removed to avoid false hits and ~4 min upload tax on cold runs.

### Safety: verify every run

Even on `cache-hit`, bash steps compare fingerprints:

- ksud: `commit=` in `app/build/generated/.../ksud/source.properties`
- LKM: `head_sha=` in `app/src/main/assets/abk_lkm/source.properties`

Mismatch → wipe directory → full rebuild of that layer only.

Heavy steps are gated with `if:`:

- `Build bundled SukiSU-Ultra ksud assets` → `needs_rebuild == true`
- `Bundle ABK LKM artifacts` → `needs_rebundle == true`

Inline build scripts are **unchanged**; only cache restore/save/verify wrappers were added.

### Gradle (`gradle.properties`)

```properties
org.gradle.parallel=true
org.gradle.caching=true
org.gradle.jvmargs=-Xmx4096m ...
```

---

## What does *not* reset the cache?

A new commit in this repo **does not** invalidate ksud/LKM caches unless you also change:

- SukiSU-Ultra `main` (new `sukisu_commit`)
- Successful LKM workflow in `ABK_control_module`
- `.github/workflows/build-abk-app*.yml` or `prepare-abk-app-inputs` (`workflow_digest`)

Normal `app/**` Kotlin/UI changes → ksud/LKM **cache hit**, Gradle incremental work only.

---

## Files changed

| File | Change |
|------|--------|
| `.github/actions/prepare-abk-app-inputs/action.yml` | New — resolve SHAs for cache keys |
| `.github/workflows/build-abk-app.yml` | Cache + verify + conditional heavy steps |
| `.github/workflows/build-abk-app-dev.yml` | Same as prod |
| `gradle.properties` | Parallel + build cache + 4G heap |

---

## Out of scope / follow-ups

- Self-hosted runner (`APP_RUNNER`) — unchanged; caches also help on hosted runners
- Prebuilt `ksud` in git — not introduced
- SDK cache via workspace-local `ANDROID_HOME` — possible future optimization (~1–3 min on cold runs)
- `org.gradle.configuration-cache` — not enabled in v1; can trial separately

