### PR TITLE
Enhance OOBE flow and update CI configuration

### DIFF
--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -73,19 +73,6 @@ jobs:
           commit="$(git -C "$source_dir" rev-parse HEAD)"
           mkdir -p "$target_dir" "$jni_target_dir"
 
-          SOURCE_DIR="$source_dir" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          path = Path(os.environ["SOURCE_DIR"]) / "userspace/ksud/src/boot_patch.rs"
-          text = path.read_text()
-          old = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_path)\n                    .context(\"copy magiskboot failed\")?;\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          new = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                let magiskboot_bin = workdir.join(\"magiskboot.bin\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_bin)\n                    .context(\"copy magiskboot failed\")?;\n                #[cfg(unix)]\n                {\n                    use std::io::Write;\n                    let mut wrapper = std::fs::File::create(&magiskboot_path)?;\n                    wrapper.write_all(b\"#!/system/bin/sh\\nLINKER=/apex/com.android.runtime/bin/linker64\\n[ -x \\\\\\\"$LINKER\\\\\\\" ] || LINKER=/system/bin/linker64\\nexec \\\\\\\"$LINKER\\\\\\\" \\\\\\\"$0.bin\\\\\\\" \\\\\\\"$@\\\\\\\"\\n\")?;\n                    let _ = std::fs::set_permissions(&magiskboot_path, std::fs::Permissions::from_mode(0o755));\n                    let _ = std::fs::set_permissions(&magiskboot_bin, std::fs::Permissions::from_mode(0o755));\n                }\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          if old not in text:
-              raise SystemExit("failed to find magiskboot injection block in boot_patch.rs")
-          path.write_text(text.replace(old, new, 1))
-          PY
-
           setup_rust_build() {
             local triple="$1"
             local android_sdk_level="$2"
@@ -179,18 +166,6 @@ jobs:
               --manifest-path "$source_dir/Cargo.toml"
           }
 
-          magiskboot_url_for_abi() {
-            case "$1" in
-              arm64-v8a) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/arm64-v8a/libmagiskboot.so" ;;
-              x86_64) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/x86_64/libmagiskboot.so" ;;
-              armeabi-v7a) printf '%s\n' "" ;;
-              *)
-                echo "::error::Unsupported magiskboot ABI: $1"
-                return 1
-                ;;
-            esac
-          }
-
           {
             echo "source_repo=$repo_url"
             echo "ref=$SUKISU_ULTRA_REF"
@@ -225,13 +200,6 @@ jobs:
               exit 1
             fi
             install -Dm755 "$ksuinit_binary" "$bin_dir/ksuinit"
-            magiskboot_url="$(magiskboot_url_for_abi "$abi")"
-            if [ -n "$magiskboot_url" ]; then
-              curl -fsSL "$magiskboot_url" -o "$bin_dir/magiskboot"
-              chmod 755 "$bin_dir/magiskboot"
-            else
-              echo "warning.$abi=magiskboot_missing_upstream" >> "$target_dir/source.properties"
-            fi
             setup_rust_build "$triple" 26
             cargo build \
               --target "$triple" \
@@ -275,7 +243,7 @@ jobs:
             echo "- Commit: $commit"
             echo "- ABIs: $SUKISU_KSUD_ABIS"
             echo "- Embedded ksuinit: aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
-            echo "- Embedded magiskboot: arm64-v8a, x86_64"
+            echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Bundle ABK LKM artifacts

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - "app/**"
+      - "app_dev/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle/**"
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - "app/**"
+      - "app_dev/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle/**"
@@ -70,19 +72,6 @@ jobs:
           git clone --depth 1 --branch "$SUKISU_ULTRA_REF" "$SUKISU_ULTRA_REPO" "$source_dir"
           commit="$(git -C "$source_dir" rev-parse HEAD)"
           mkdir -p "$target_dir" "$jni_target_dir"
-
-          SOURCE_DIR="$source_dir" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          path = Path(os.environ["SOURCE_DIR"]) / "userspace/ksud/src/boot_patch.rs"
-          text = path.read_text()
-          old = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_path)\n                    .context(\"copy magiskboot failed\")?;\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          new = """            } else {\n                let magiskboot_path = workdir.join(\"magiskboot\");\n                let magiskboot_bin = workdir.join(\"magiskboot.bin\");\n                assets::copy_assets_to_file(\"magiskboot\", &magiskboot_bin)\n                    .context(\"copy magiskboot failed\")?;\n                #[cfg(unix)]\n                {\n                    use std::io::Write;\n                    let mut wrapper = std::fs::File::create(&magiskboot_path)?;\n                    wrapper.write_all(b\"#!/system/bin/sh\\nLINKER=/apex/com.android.runtime/bin/linker64\\n[ -x \\\\\\\"$LINKER\\\\\\\" ] || LINKER=/system/bin/linker64\\nexec \\\\\\\"$LINKER\\\\\\\" \\\\\\\"$0.bin\\\\\\\" \\\\\\\"$@\\\\\\\"\\n\")?;\n                    let _ = std::fs::set_permissions(&magiskboot_path, std::fs::Permissions::from_mode(0o755));\n                    let _ = std::fs::set_permissions(&magiskboot_bin, std::fs::Permissions::from_mode(0o755));\n                }\n                magiskboot_path\n            };\n            ensure!(magiskboot.exists(), \"{} is not exist\", magiskboot.display());\n            #[cfg(unix)]\n            let _ = std::fs::set_permissions(&magiskboot, std::fs::Permissions::from_mode(0o755));\n            magiskboot\n"""
-          if old not in text:
-              raise SystemExit("failed to find magiskboot injection block in boot_patch.rs")
-          path.write_text(text.replace(old, new, 1))
-          PY
 
           setup_rust_build() {
             local triple="$1"
@@ -177,18 +166,6 @@ jobs:
               --manifest-path "$source_dir/Cargo.toml"
           }
 
-          magiskboot_url_for_abi() {
-            case "$1" in
-              arm64-v8a) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/arm64-v8a/libmagiskboot.so" ;;
-              x86_64) printf '%s\n' "https://raw.githubusercontent.com/SukiSU-Ultra/SukiSU-Ultra/main/manager/app/src/main/jniLibs/x86_64/libmagiskboot.so" ;;
-              armeabi-v7a) printf '%s\n' "" ;;
-              *)
-                echo "::error::Unsupported magiskboot ABI: $1"
-                return 1
-                ;;
-            esac
-          }
-
           {
             echo "source_repo=$repo_url"
             echo "ref=$SUKISU_ULTRA_REF"
@@ -223,13 +200,6 @@ jobs:
               exit 1
             fi
             install -Dm755 "$ksuinit_binary" "$bin_dir/ksuinit"
-            magiskboot_url="$(magiskboot_url_for_abi "$abi")"
-            if [ -n "$magiskboot_url" ]; then
-              curl -fsSL "$magiskboot_url" -o "$bin_dir/magiskboot"
-              chmod 755 "$bin_dir/magiskboot"
-            else
-              echo "warning.$abi=magiskboot_missing_upstream" >> "$target_dir/source.properties"
-            fi
             setup_rust_build "$triple" 26
             cargo build \
               --target "$triple" \
@@ -273,7 +243,7 @@ jobs:
             echo "- Commit: $commit"
             echo "- ABIs: $SUKISU_KSUD_ABIS"
             echo "- Embedded ksuinit: aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
-            echo "- Embedded magiskboot: arm64-v8a, x86_64"
+            echo "- magiskboot: removed upstream (ksud uses bootimg crate)"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Bundle ABK LKM artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,7 @@ jobs:
           SUKISU_REPO="SukiSU-Ultra/SukiSU-Ultra"
 
           # Dev 固定引用先完整复制 Stable 配置，后续只改这里的 *_DEV_REF 即可。
-          OFFICIAL_DEV_REF="290609c945728fc93d85735918793567588103c1"
+          OFFICIAL_DEV_REF="96a72dd0107d660adcb273ab1911e1e77d87e562"
           SUKISU_DEV_REF="aac170bcb86ce45516b3e2c0e2b32b57004b8f73"
           RESUKISU_DEV_REF="fb771414f249ab886c09f2cfcbbf91c4b4dab2d1"
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -51,7 +51,7 @@ This document records the open source projects, embedded code, generated binarie
 
 ## APK-Bundled SukiSU Components
 
-The APK build workflows compile `userspace/ksud` from `SukiSU-Ultra/SukiSU-Ultra` and download `libmagiskboot.so` from that upstream manager tree for supported ABIs. Prebuilt `ksud` binaries are not committed to this repository. The pinned upstream ref is declared in `.github/workflows/build-abk-app.yml` and `.github/workflows/build-abk-app-dev.yml`.
+The APK build workflows compile `userspace/ksud` from `SukiSU-Ultra/SukiSU-Ultra` for supported ABIs. Upstream ksud patches boot images with the in-process `android_bootimg` crate and no longer ships or requires `libmagiskboot.so`. Prebuilt `ksud` binaries are not committed to this repository. The upstream ref is declared in `.github/workflows/build-abk-app.yml` and `.github/workflows/build-abk-app-dev.yml`.
 
 ## Android / Gradle Dependencies
 

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -78,11 +78,11 @@ import androidx.compose.ui.zIndex
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
-import com.abk.kernel.ui.screens.AuthGateScreen
 import com.abk.kernel.ui.screens.BuildScreen
 import com.abk.kernel.ui.screens.FlashScreen
 import com.abk.kernel.ui.screens.InstalledModulesScreen
 import com.abk.kernel.ui.screens.ModuleRepositoryScreen
+import com.abk.kernel.ui.screens.OobeScreen
 import com.abk.kernel.ui.screens.RootAuthorizationScreen
 import com.abk.kernel.ui.screens.RuntimeHomeScreen
 import com.abk.kernel.ui.screens.SettingsScreen
@@ -90,7 +90,6 @@ import com.abk.kernel.ui.screens.StatusScreen
 import com.abk.kernel.ui.theme.AbkTheme
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.ui.theme.uiSurfaceColor
-import com.abk.kernel.viewmodel.AuthStep
 import com.abk.kernel.viewmodel.MainViewModel
 
 class MainActivity : ComponentActivity() {
@@ -113,9 +112,19 @@ class MainActivity : ComponentActivity() {
             val vm: MainViewModel = viewModel()
             val state by vm.uiState.collectAsState()
 
+            LaunchedEffect(Unit) {
+                vm.checkRoot()
+            }
+
             LaunchedEffect(state.termsAccepted) {
                 if (state.termsAccepted && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     requestNotifications.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+
+            LaunchedEffect(state.termsAccepted, state.oobeCompleted) {
+                if (state.termsAccepted && !state.oobeCompleted) {
+                    vm.maybeShowInitialOobe()
                 }
             }
 
@@ -139,12 +148,23 @@ class MainActivity : ComponentActivity() {
                             onAccept = vm::acceptTerms,
                             onDecline = { finishAffinity() }
                         )
-                        state.authStep != AuthStep.READY -> AuthGateScreen(vm)
-                        else -> AbkMainScaffold(
-                            vm = vm,
-                            pendingModuleInstallUri = pendingModuleInstallUri,
-                            onModuleInstallUriConsumed = { pendingModuleInstallUri = null }
-                        )
+                        else -> Box(modifier = Modifier.fillMaxSize()) {
+                            AbkMainScaffold(
+                                vm = vm,
+                                pendingModuleInstallUri = pendingModuleInstallUri,
+                                onModuleInstallUriConsumed = { pendingModuleInstallUri = null }
+                            )
+                            if (state.showSyncPrompt && !state.showOobe) {
+                                SyncPromptDialog(
+                                    behindBy = state.behindBy,
+                                    onSync = vm::syncFork,
+                                    onDismiss = vm::dismissSyncPrompt
+                                )
+                            }
+                            if (state.showOobe) {
+                                OobeScreen(vm)
+                            }
+                        }
                     }
                 }
             }
@@ -156,6 +176,34 @@ class MainActivity : ComponentActivity() {
         setIntent(intent)
         pendingModuleInstallUri = extractModuleInstallUri(intent)?.toString()
     }
+}
+
+@Composable
+private fun SyncPromptDialog(
+    behindBy: Int,
+    onSync: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.sync_title)) },
+        text = {
+            Text(
+                "${stringResource(R.string.sync_desc)}\n\n" +
+                    stringResource(R.string.sync_behind_commits, behindBy)
+            )
+        },
+        confirmButton = {
+            Button(onClick = onSync) {
+                Text(stringResource(R.string.sync_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.skip))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -162,7 +162,16 @@ class MainActivity : ComponentActivity() {
                                 )
                             }
                             if (state.showOobe) {
-                                OobeScreen(vm)
+                                CompositionLocalProvider(LocalUiSurfaceAlpha provides 1f) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .background(MaterialTheme.colorScheme.surface)
+                                            .zIndex(4f)
+                                    ) {
+                                        OobeScreen(vm)
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/abk/kernel/data/api/NetworkClient.kt
+++ b/app/src/main/java/com/abk/kernel/data/api/NetworkClient.kt
@@ -33,7 +33,7 @@ object NetworkClient {
             .build()
     }
 
-    fun createApiService(token: String): GitHubApiService {
+    fun createApiService(token: String? = null): GitHubApiService {
         return Retrofit.Builder()
             .baseUrl(GITHUB_API_BASE)
             .client(buildOkHttpClient(token))

--- a/app/src/main/java/com/abk/kernel/data/repository/GitHubRepository.kt
+++ b/app/src/main/java/com/abk/kernel/data/repository/GitHubRepository.kt
@@ -27,7 +27,7 @@ sealed class Result<out T> {
 
 class GitHubRepository(
     private val authService: GitHubAuthService = NetworkClient.createAuthService(),
-    private var apiService: GitHubApiService? = null
+    private var apiService: GitHubApiService = NetworkClient.createApiService()
 ) {
     private val clientId = BuildConfig.GITHUB_CLIENT_ID
     private val publicHttpClient = OkHttpClient.Builder()
@@ -35,7 +35,7 @@ class GitHubRepository(
         .readTimeout(60, TimeUnit.SECONDS)
         .build()
 
-    fun updateToken(token: String) {
+    fun updateToken(token: String?) {
         apiService = NetworkClient.createApiService(token)
     }
 
@@ -193,7 +193,7 @@ class GitHubRepository(
     // ── User ──────────────────────────────────────────────────────────────
 
     suspend fun getAuthenticatedUser(): Result<GitHubUser> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.getAuthenticatedUser()
             if (resp.isSuccessful && resp.body() != null) Result.Success(resp.body()!!)
@@ -204,7 +204,7 @@ class GitHubRepository(
     // ── Fork ──────────────────────────────────────────────────────────────
 
     suspend fun getUserFork(sourceOwner: String, sourceRepo: String, username: String): Result<GitHubRepo?> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.getRepo(username, sourceRepo)
             val repo = resp.body()
@@ -220,7 +220,7 @@ class GitHubRepository(
     }
 
     suspend fun forkRepo(owner: String, repo: String): Result<GitHubRepo> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.forkRepo(owner, repo)
             if (resp.isSuccessful && resp.body() != null) Result.Success(resp.body()!!)
@@ -235,7 +235,7 @@ class GitHubRepository(
         headOwner: String,
         headBranch: String
     ): Result<CompareResult> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.compareCommits(
                 sourceOwner,
@@ -248,7 +248,7 @@ class GitHubRepository(
     }
 
     suspend fun syncFork(username: String, repo: String, branch: String): Result<SyncForkResponse> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.syncFork(username, repo, SyncForkRequest(branch))
             if (resp.isSuccessful && resp.body() != null) Result.Success(resp.body()!!)
@@ -259,7 +259,7 @@ class GitHubRepository(
     // ── Workflows ─────────────────────────────────────────────────────────
 
     suspend fun getWorkflow(owner: String, repo: String, workflowFile: String): Result<Workflow> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.listWorkflows(owner, repo)
             if (resp.isSuccessful) {
@@ -287,7 +287,7 @@ class GitHubRepository(
         inputs: Map<String, String>,
         ref: String = "main"
     ): Result<Unit> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.dispatchWorkflow(owner, repo, workflowId.toString(), WorkflowDispatchRequest(ref, inputs))
             if (resp.isSuccessful) Result.Success(Unit)
@@ -296,7 +296,7 @@ class GitHubRepository(
     }
 
     suspend fun enableWorkflow(owner: String, repo: String, workflowId: Long): Result<Unit> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.enableWorkflow(owner, repo, workflowId.toString())
             if (resp.isSuccessful) Result.Success(Unit)
@@ -310,7 +310,7 @@ class GitHubRepository(
         perPage: Int = 10,
         workflowId: Long? = null
     ): Result<List<WorkflowRun>> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<List<WorkflowRun>>> {
             val resp = api.listWorkflowRuns(
                 owner,
@@ -328,7 +328,7 @@ class GitHubRepository(
     }
 
     suspend fun getWorkflowRun(owner: String, repo: String, runId: Long): Result<WorkflowRun> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.getWorkflowRun(owner, repo, runId)
             if (resp.isSuccessful && resp.body() != null) Result.Success(resp.body()!!)
@@ -337,7 +337,7 @@ class GitHubRepository(
     }
 
     suspend fun deleteWorkflowRun(owner: String, repo: String, runId: Long): Result<Unit> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.deleteWorkflowRun(owner, repo, runId)
             when {
@@ -348,7 +348,7 @@ class GitHubRepository(
     }
 
     suspend fun cancelWorkflowRun(owner: String, repo: String, runId: Long): Result<Unit> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching {
             val resp = api.cancelWorkflowRun(owner, repo, runId)
             when {
@@ -359,7 +359,7 @@ class GitHubRepository(
     }
 
     suspend fun listRunJobs(owner: String, repo: String, runId: Long): Result<List<WorkflowJob>> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<List<WorkflowJob>>> {
             val resp = api.listRunJobs(owner, repo, runId)
             if (resp.isSuccessful) {
@@ -372,7 +372,7 @@ class GitHubRepository(
     }
 
     suspend fun downloadJobLogs(owner: String, repo: String, jobId: Long): Result<String> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<String>> {
             val resp = api.downloadJobLogs(owner, repo, jobId)
             if (resp.isSuccessful) {
@@ -385,7 +385,7 @@ class GitHubRepository(
     }
 
     suspend fun downloadRunLogs(owner: String, repo: String, runId: Long): Result<String> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<String>> {
             val resp = api.downloadRunLogs(owner, repo, runId)
             if (resp.isSuccessful) {
@@ -398,7 +398,7 @@ class GitHubRepository(
     }
 
     suspend fun listArtifacts(owner: String, repo: String, runId: Long): Result<List<Artifact>> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<List<Artifact>>> {
             val resp = api.listArtifacts(owner, repo, runId)
             if (resp.isSuccessful) {
@@ -411,7 +411,7 @@ class GitHubRepository(
     }
 
     suspend fun listReleases(owner: String, repo: String, perPage: Int = 100): Result<List<GitHubReleaseSummary>> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<List<GitHubReleaseSummary>>> {
             val collected = mutableListOf<GitHubReleaseSummary>()
             var page = 1
@@ -430,7 +430,7 @@ class GitHubRepository(
     }
 
     suspend fun getReleaseByTag(owner: String, repo: String, tag: String): Result<GitHubRelease?> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<GitHubRelease?>> {
             val resp = api.getReleaseByTag(owner, repo, tag)
             when {
@@ -447,7 +447,7 @@ class GitHubRepository(
         releaseId: Long,
         perPage: Int = 100
     ): Result<List<ReleaseAsset>> {
-        val api = apiService ?: return Result.Error("Not authenticated")
+        val api = apiService
         return runCatching<Result<List<ReleaseAsset>>> {
             val collected = mutableListOf<ReleaseAsset>()
             var page = 1

--- a/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
@@ -47,6 +47,7 @@ class PreferencesRepository(private val context: Context) {
         val KEY_RUNTIME_NAVIGATION_ENABLED = booleanPreferencesKey("runtime_navigation_enabled")
         val KEY_WEBVIEW_DEBUG_ENABLED = booleanPreferencesKey("webview_debug_enabled")
         val KEY_TERMS_ACCEPTED_VERSION = intPreferencesKey("terms_accepted_version")
+        val KEY_OOBE_COMPLETED = booleanPreferencesKey("oobe_completed")
     }
 
     val accessToken: Flow<String?> = context.dataStore.data.map { it[KEY_ACCESS_TOKEN] }
@@ -89,6 +90,7 @@ class PreferencesRepository(private val context: Context) {
         it[KEY_WEBVIEW_DEBUG_ENABLED] ?: false
     }
     val termsAcceptedVersion: Flow<Int> = context.dataStore.data.map { it[KEY_TERMS_ACCEPTED_VERSION] ?: 0 }
+    val oobeCompleted: Flow<Boolean> = context.dataStore.data.map { it[KEY_OOBE_COMPLETED] ?: false }
 
     suspend fun saveToken(token: String) = context.dataStore.edit { it[KEY_ACCESS_TOKEN] = token }
     suspend fun saveUsername(name: String) = context.dataStore.edit { it[KEY_USERNAME] = name }
@@ -163,6 +165,9 @@ class PreferencesRepository(private val context: Context) {
     }
     suspend fun acceptCurrentTerms() = context.dataStore.edit {
         it[KEY_TERMS_ACCEPTED_VERSION] = CURRENT_TERMS_VERSION
+    }
+    suspend fun setOobeCompleted(v: Boolean) = context.dataStore.edit {
+        it[KEY_OOBE_COMPLETED] = v
     }
     suspend fun clearPendingAutoDownloadRunId() = context.dataStore.edit { it.remove(KEY_PENDING_AUTO_DOWNLOAD_RUN_ID) }
 

--- a/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
@@ -184,9 +184,6 @@ fun AbkRootPatchScreen(
     val userlandKsudPath by produceState<String?>(initialValue = null, context) {
         value = withContext(Dispatchers.IO) { RootUtils.resolveUserlandKsudPath(context) }
     }
-    val userlandMagiskbootPath by produceState<String?>(initialValue = null, context) {
-        value = withContext(Dispatchers.IO) { RootUtils.resolveUserlandMagiskbootPath(context) }
-    }
     val hasLocalLkm = selectedLocalLkmPath.isNotBlank()
     val activeLkmLabel = selectedLocalLkmName.takeIf { it.isNotBlank() }
         ?: selectedAsset?.let { "${it.variantLabel} · ${it.kmi}" }
@@ -194,11 +191,10 @@ fun AbkRootPatchScreen(
     val hasLkmSource = hasLocalLkm || selectedAsset != null
     val showRootInstallModes = rootGranted
     val hasUserlandKsud = userlandKsudPath != null
-    val hasUserlandMagiskboot = userlandMagiskbootPath != null
     val canPatchSelectedFile = selectedBootPath.isNotBlank() &&
         hasLkmSource &&
         !running &&
-        (rootGranted || (hasUserlandKsud && hasUserlandMagiskboot))
+        (rootGranted || hasUserlandKsud)
     val canDirectInstall = rootGranted && hasLkmSource && !running
     val canFlashAnyKernel3 = rootGranted && selectedAnyKernelPath.isNotBlank() && !running
     val canProceed = when (selectedMode) {
@@ -788,11 +784,8 @@ fun AbkRootPatchScreen(
             if (!hasLkmSource && selectedMode != LkmPatchInstallMode.AnyKernel3) {
                 InlineWarning(stringResource(R.string.root_patch_warn_no_lkm))
             }
-            if (selectedMode == LkmPatchInstallMode.SelectFile && !rootGranted) {
-                when {
-                    !hasUserlandKsud -> InlineWarning(stringResource(R.string.root_patch_warn_no_ksud))
-                    !hasUserlandMagiskboot -> InlineWarning(stringResource(R.string.root_patch_warn_no_magiskboot))
-                }
+            if (selectedMode == LkmPatchInstallMode.SelectFile && !rootGranted && !hasUserlandKsud) {
+                InlineWarning(stringResource(R.string.root_patch_warn_no_ksud))
             }
 
             Button(

--- a/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
@@ -96,7 +96,6 @@ fun OobeScreen(vm: MainViewModel) {
                     shape = RoundedCornerShape(exitCorner)
                     clip = visualSkipExitProgress > 0.01f
                 }
-        )
         ) {
             when (state.authStep) {
                 AuthStep.INTRO -> OobeIntroScreen(

--- a/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
@@ -8,8 +8,10 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.*
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -18,7 +20,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -32,51 +37,145 @@ import com.abk.kernel.ui.components.ExpressiveStatusChip
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.viewmodel.AuthStep
 import com.abk.kernel.viewmodel.MainViewModel
+import kotlin.math.pow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val OOBE_SKIP_LOADING_DELAY_MS = 320L
+private const val OOBE_SKIP_EXIT_DELAY_MS = 280L
+private const val OOBE_SKIP_BACK_VISUAL_EXPONENT = 1.8f
+private const val OOBE_SKIP_BACK_SCALE_DELTA = 0.09f
+private val OOBE_SKIP_MAX_CORNER = 32.dp
 
 @Composable
 fun OobeScreen(vm: MainViewModel) {
     val state by vm.uiState.collectAsState()
+    val scope = rememberCoroutineScope()
+    var skipInFlight by remember { mutableStateOf(false) }
+    var skipExitStarted by remember { mutableStateOf(false) }
+    val motionScheme = MaterialTheme.motionScheme
+    val animatedSkipExitProgress by animateFloatAsState(
+        targetValue = if (skipExitStarted) 1f else 0f,
+        animationSpec = motionScheme.fastSpatialSpec(),
+        label = "oobe-skip-exit-progress"
+    )
+    val visualSkipExitProgress = animatedSkipExitProgress
+        .coerceIn(0f, 1f)
+        .pow(OOBE_SKIP_BACK_VISUAL_EXPONENT)
+    val density = LocalDensity.current
 
-    when (state.authStep) {
-        AuthStep.INTRO -> OobeIntroScreen(
-            loggedIn = state.isLoggedIn,
-            onContinue = {
-                if (state.isLoggedIn) {
-                    vm.openBuildOobe()
-                } else {
-                    vm.continueOobeToLogin()
+    fun requestSkip() {
+        if (skipInFlight) return
+        skipInFlight = true
+        scope.launch {
+            delay(OOBE_SKIP_LOADING_DELAY_MS)
+            skipExitStarted = true
+            delay(OOBE_SKIP_EXIT_DELAY_MS)
+            vm.skipOobe()
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+    ) {
+        val exitWidthPx = with(density) { maxWidth.toPx() }
+        val exitCorner = with(density) {
+            (OOBE_SKIP_MAX_CORNER.toPx() * visualSkipExitProgress).toDp()
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    translationX = exitWidthPx * animatedSkipExitProgress
+                    scaleX = 1f - OOBE_SKIP_BACK_SCALE_DELTA * visualSkipExitProgress
+                    scaleY = 1f - OOBE_SKIP_BACK_SCALE_DELTA * visualSkipExitProgress
+                    alpha = 1f - 0.08f * visualSkipExitProgress
+                    shape = RoundedCornerShape(exitCorner)
+                    clip = visualSkipExitProgress > 0.01f
                 }
-            },
-            onSkip = { vm.skipOobe() }
         )
-        AuthStep.LOGIN -> LoginScreen(
-            isLoading = state.isLoading,
-            userCode = state.userCode,
-            verificationUri = state.verificationUri,
-            isPolling = state.isPollingToken,
-            error = state.error,
-            onLogin = { vm.startDeviceFlow() },
-            onSkip = { vm.skipOobe() },
-            onClearError = { vm.clearError() }
-        )
-        AuthStep.FORK_CHECK -> ForkCheckScreen(
-            isLoading = state.isLoading,
-            hasFork = state.forkRepo != null,
-            behindBy = state.behindBy,
-            showSyncDialog = false,
-            error = state.error,
-            onFork = { vm.forkRepo() },
-            onSync = { vm.syncFork() },
-            onSkip = { vm.skipOobe() },
-            showSkipAction = true,
-            onClearError = { vm.clearError() }
-        )
+        ) {
+            when (state.authStep) {
+                AuthStep.INTRO -> OobeIntroScreen(
+                    loggedIn = state.isLoggedIn,
+                    skipping = skipInFlight,
+                    onContinue = {
+                        if (!skipInFlight) {
+                            if (state.isLoggedIn) {
+                                vm.openBuildOobe()
+                            } else {
+                                vm.continueOobeToLogin()
+                            }
+                        }
+                    },
+                    onSkip = ::requestSkip
+                )
+                AuthStep.LOGIN -> LoginScreen(
+                    isLoading = state.isLoading,
+                    userCode = state.userCode,
+                    verificationUri = state.verificationUri,
+                    isPolling = state.isPollingToken,
+                    error = state.error,
+                    onLogin = { if (!skipInFlight) vm.startDeviceFlow() },
+                    onSkip = ::requestSkip,
+                    skipInFlight = skipInFlight,
+                    onClearError = { vm.clearError() }
+                )
+                AuthStep.FORK_CHECK -> ForkCheckScreen(
+                    isLoading = state.isLoading,
+                    hasFork = state.forkRepo != null,
+                    behindBy = state.behindBy,
+                    showSyncDialog = false,
+                    error = state.error,
+                    onFork = { if (!skipInFlight) vm.forkRepo() },
+                    onSync = { if (!skipInFlight) vm.syncFork() },
+                    onSkip = ::requestSkip,
+                    showSkipAction = true,
+                    skipInFlight = skipInFlight,
+                    onClearError = { vm.clearError() }
+                )
+            }
+        }
+
+        if (skipInFlight) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.16f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    tonalElevation = 0.dp,
+                    shadowElevation = 0.dp
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        LoadingIndicator(Modifier.size(28.dp))
+                        Text(
+                            text = stringResource(R.string.loading),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 
 @Composable
 private fun OobeIntroScreen(
     loggedIn: Boolean,
+    skipping: Boolean,
     onContinue: () -> Unit,
     onSkip: () -> Unit
 ) {
@@ -117,6 +216,7 @@ private fun OobeIntroScreen(
         }
         Button(
             onClick = onContinue,
+            enabled = !skipping,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp)
@@ -131,7 +231,7 @@ private fun OobeIntroScreen(
                 }
             )
         }
-        TextButton(onClick = onSkip) {
+        TextButton(onClick = onSkip, enabled = !skipping) {
             Text(stringResource(R.string.oobe_skip_for_now))
         }
     }
@@ -192,6 +292,7 @@ private fun LoginScreen(
     error: String?,
     onLogin: () -> Unit,
     onSkip: () -> Unit,
+    skipInFlight: Boolean,
     onClearError: () -> Unit
 ) {
     val context = LocalContext.current
@@ -257,7 +358,7 @@ private fun LoginScreen(
         if (userCode == null) {
             Button(
                 onClick = { showConsentDialog = true },
-                enabled = !isLoading,
+                enabled = !isLoading && !skipInFlight,
                 modifier = Modifier.fillMaxWidth().height(52.dp)
             ) {
                 if (isLoading) {
@@ -270,7 +371,7 @@ private fun LoginScreen(
             }
         }
 
-        TextButton(onClick = onSkip) {
+        TextButton(onClick = onSkip, enabled = !skipInFlight) {
             Text(stringResource(R.string.oobe_skip_for_now))
         }
     }
@@ -393,6 +494,7 @@ private fun ForkCheckScreen(
     onSync: () -> Unit,
     onSkip: () -> Unit,
     showSkipAction: Boolean = false,
+    skipInFlight: Boolean = false,
     onClearError: () -> Unit
 ) {
     if (showSyncDialog) {
@@ -445,6 +547,7 @@ private fun ForkCheckScreen(
             )
             Button(
                 onClick = onFork,
+                enabled = !skipInFlight,
                 modifier = Modifier.fillMaxWidth().height(52.dp)
             ) {
                 Icon(Icons.Default.ForkRight, null)
@@ -479,7 +582,7 @@ private fun ForkCheckScreen(
             ErrorCard(error = error, onClearError = onClearError)
         }
         if (showSkipAction) {
-            TextButton(onClick = onSkip) {
+            TextButton(onClick = onSkip, enabled = !skipInFlight) {
                 Text(stringResource(R.string.oobe_skip_for_now))
             }
         }

--- a/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
@@ -34,17 +34,20 @@ import com.abk.kernel.viewmodel.AuthStep
 import com.abk.kernel.viewmodel.MainViewModel
 
 @Composable
-fun AuthGateScreen(vm: MainViewModel) {
+fun OobeScreen(vm: MainViewModel) {
     val state by vm.uiState.collectAsState()
 
-    LaunchedEffect(Unit) {
-        vm.checkRoot()
-    }
-
     when (state.authStep) {
-        AuthStep.CHECK_ROOT -> RootCheckScreen(
-            isLoading = state.isLoading,
-            onRequestRoot = { vm.requestRoot() }
+        AuthStep.INTRO -> OobeIntroScreen(
+            loggedIn = state.isLoggedIn,
+            onContinue = {
+                if (state.isLoggedIn) {
+                    vm.openBuildOobe()
+                } else {
+                    vm.continueOobeToLogin()
+                }
+            },
+            onSkip = { vm.skipOobe() }
         )
         AuthStep.LOGIN -> LoginScreen(
             isLoading = state.isLoading,
@@ -53,20 +56,84 @@ fun AuthGateScreen(vm: MainViewModel) {
             isPolling = state.isPollingToken,
             error = state.error,
             onLogin = { vm.startDeviceFlow() },
+            onSkip = { vm.skipOobe() },
             onClearError = { vm.clearError() }
         )
         AuthStep.FORK_CHECK -> ForkCheckScreen(
             isLoading = state.isLoading,
             hasFork = state.forkRepo != null,
             behindBy = state.behindBy,
-            showSyncDialog = state.showSyncDialog,
+            showSyncDialog = false,
             error = state.error,
             onFork = { vm.forkRepo() },
             onSync = { vm.syncFork() },
-            onSkip = { vm.dismissSyncDialog() },
+            onSkip = { vm.skipOobe() },
+            showSkipAction = true,
             onClearError = { vm.clearError() }
         )
-        AuthStep.READY -> { /* handled by parent */ }
+    }
+}
+
+@Composable
+private fun OobeIntroScreen(
+    loggedIn: Boolean,
+    onContinue: () -> Unit,
+    onSkip: () -> Unit
+) {
+    AuthShell {
+        ExpressiveHeroCard(
+            title = stringResource(R.string.oobe_title),
+            subtitle = stringResource(R.string.oobe_desc),
+            icon = Icons.Default.RocketLaunch,
+            badge = {
+                ExpressiveStatusChip(
+                    label = stringResource(R.string.oobe_first_launch),
+                    icon = Icons.Default.AutoAwesome,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        )
+        ExpressiveSectionCard(
+            title = stringResource(R.string.oobe_build_title),
+            subtitle = stringResource(R.string.oobe_build_desc),
+            icon = Icons.Default.Code
+        ) {
+            Text(
+                stringResource(R.string.oobe_build_detail),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        ExpressiveSectionCard(
+            title = stringResource(R.string.oobe_flash_title),
+            subtitle = stringResource(R.string.oobe_flash_desc),
+            icon = Icons.Default.CloudDownload
+        ) {
+            Text(
+                stringResource(R.string.oobe_flash_detail),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Button(
+            onClick = onContinue,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+        ) {
+            Icon(if (loggedIn) Icons.Default.ForkRight else Icons.Default.Code, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(
+                if (loggedIn) {
+                    stringResource(R.string.oobe_continue_setup)
+                } else {
+                    stringResource(R.string.login_github)
+                }
+            )
+        }
+        TextButton(onClick = onSkip) {
+            Text(stringResource(R.string.oobe_skip_for_now))
+        }
     }
 }
 
@@ -124,6 +191,7 @@ private fun LoginScreen(
     isPolling: Boolean,
     error: String?,
     onLogin: () -> Unit,
+    onSkip: () -> Unit,
     onClearError: () -> Unit
 ) {
     val context = LocalContext.current
@@ -200,6 +268,10 @@ private fun LoginScreen(
                     Text(stringResource(R.string.login_github))
                 }
             }
+        }
+
+        TextButton(onClick = onSkip) {
+            Text(stringResource(R.string.oobe_skip_for_now))
         }
     }
 }
@@ -318,6 +390,7 @@ private fun ForkCheckScreen(
     onFork: () -> Unit,
     onSync: () -> Unit,
     onSkip: () -> Unit,
+    showSkipAction: Boolean = false,
     onClearError: () -> Unit
 ) {
     if (showSyncDialog) {
@@ -402,6 +475,11 @@ private fun ForkCheckScreen(
         }
         if (error != null) {
             ErrorCard(error = error, onClearError = onClearError)
+        }
+        if (showSkipAction) {
+            TextButton(onClick = onSkip) {
+                Text(stringResource(R.string.oobe_skip_for_now))
+            }
         }
     }
 }

--- a/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AuthGateScreen.kt
@@ -29,7 +29,7 @@ import com.abk.kernel.R
 import com.abk.kernel.ui.components.ExpressiveHeroCard
 import com.abk.kernel.ui.components.ExpressiveSectionCard
 import com.abk.kernel.ui.components.ExpressiveStatusChip
-import com.abk.kernel.ui.theme.uiSurfaceColor
+import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.viewmodel.AuthStep
 import com.abk.kernel.viewmodel.MainViewModel
 
@@ -278,23 +278,25 @@ private fun LoginScreen(
 
 @Composable
 private fun AuthShell(content: @Composable ColumnScope.() -> Unit) {
-    Scaffold(containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surface)) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(uiSurfaceColor(MaterialTheme.colorScheme.surface))
-                .padding(padding),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
+    CompositionLocalProvider(LocalUiSurfaceAlpha provides 1f) {
+        Scaffold(containerColor = MaterialTheme.colorScheme.surface) { padding ->
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 24.dp)
-                    .verticalScroll(rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(18.dp),
-                content = content
-            )
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 24.dp)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                    content = content
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
@@ -642,6 +642,81 @@ fun BuildScreen(
         )
     }
 
+    if (!state.isLoggedIn || state.forkRepo == null) {
+        val needsLogin = !state.isLoggedIn
+        Scaffold(
+            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surface),
+            topBar = {
+                ExpressiveTopBar(
+                    title = stringResource(R.string.build_title),
+                    scrollBehavior = scrollBehavior
+                )
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+                    .padding(horizontal = AbkScreenHorizontalPadding)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ExpressiveHeroCard(
+                    title = stringResource(
+                        if (needsLogin) {
+                            R.string.build_login_required_title
+                        } else {
+                            R.string.build_fork_required_title
+                        }
+                    ),
+                    subtitle = stringResource(
+                        if (needsLogin) {
+                            R.string.build_login_required_desc
+                        } else {
+                            R.string.build_fork_required_desc
+                        }
+                    ),
+                    icon = if (needsLogin) Icons.Default.Code else Icons.Default.ForkRight,
+                    badge = {
+                        ExpressiveStatusChip(
+                            label = stringResource(
+                                if (needsLogin) {
+                                    R.string.github_auth_required
+                                } else {
+                                    R.string.fork_create_badge
+                                }
+                            ),
+                            icon = if (needsLogin) Icons.Default.VerifiedUser else Icons.Default.CallSplit,
+                            color = if (needsLogin) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary
+                        )
+                    }
+                )
+                Button(
+                    onClick = vm::openBuildOobe,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp)
+                ) {
+                    Icon(
+                        if (needsLogin) Icons.Default.Code else Icons.Default.ForkRight,
+                        contentDescription = null
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        stringResource(
+                            if (needsLogin) {
+                                R.string.login_github
+                            } else {
+                                R.string.oobe_continue_setup
+                            }
+                        )
+                    )
+                }
+            }
+        }
+        return
+    }
+
     BoxWithConstraints(Modifier.fillMaxSize()) {
         val childPageTopInset = outerPadding.calculateTopPadding()
         val childPageBottomInset = outerPadding.calculateBottomPadding()

--- a/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
@@ -198,7 +199,12 @@ fun FlashScreen(
     var terminalSuccess by remember { mutableStateOf<Boolean?>(null) }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     val rootGranted = state.rootGranted
-    val currentContentTab = if (state.prebuiltGkiEnabled) activeContentTab else FlashContentTab.Workflows
+    val prebuiltOnlyMode = !state.isLoggedIn
+    val currentContentTab = when {
+        prebuiltOnlyMode -> FlashContentTab.PrebuiltGki
+        state.prebuiltGkiEnabled -> activeContentTab
+        else -> FlashContentTab.Workflows
+    }
     val supportsAnyKernelInactiveSlot by produceState(initialValue = false, rootGranted) {
         value = withContext(Dispatchers.IO) { RootUtils.supportsAnyKernelInactiveSlot() }
     }
@@ -214,13 +220,19 @@ fun FlashScreen(
         state.recentRuns.firstOrNull { it.id == state.pendingAutoDownloadRunId }
     }
 
-    val remoteArtifacts = remember(state.artifacts) {
-        state.artifacts.filter {
-            !it.expired && DownloadUtils.classifyCategory(DownloadUtils.classifyArtifact(it.name)) != null
+    val remoteArtifacts = remember(state.artifacts, state.isLoggedIn) {
+        if (!state.isLoggedIn) {
+            emptyList()
+        } else {
+            state.artifacts.filter {
+                !it.expired && DownloadUtils.classifyCategory(DownloadUtils.classifyArtifact(it.name)) != null
+            }
         }
     }
-    val workflowDownloadedArtifacts = remember(state.downloadedArtifacts, state.prebuiltGkiEnabled) {
-        if (state.prebuiltGkiEnabled) {
+    val workflowDownloadedArtifacts = remember(state.downloadedArtifacts, state.prebuiltGkiEnabled, state.isLoggedIn) {
+        if (!state.isLoggedIn) {
+            emptyList()
+        } else if (state.prebuiltGkiEnabled) {
             state.downloadedArtifacts.filterNot { it.runId == PREBUILT_GKI_RUN_ID }
         } else {
             state.downloadedArtifacts
@@ -255,8 +267,8 @@ fun FlashScreen(
         }
     }
 
-    LaunchedEffect(state.forkRepo?.fullName) {
-        if (state.forkRepo != null) vm.loadRecentRuns()
+    LaunchedEffect(state.isLoggedIn, state.forkRepo?.fullName) {
+        if (state.isLoggedIn && state.forkRepo != null) vm.loadRecentRuns()
     }
 
     LaunchedEffect(state.prebuiltGkiEnabled) {
@@ -276,8 +288,8 @@ fun FlashScreen(
         }
     }
 
-    LaunchedEffect(currentContentTab, state.prebuiltGkiEnabled, state.isLoggedIn) {
-        if (currentContentTab == FlashContentTab.PrebuiltGki && state.prebuiltGkiEnabled && state.isLoggedIn) {
+    LaunchedEffect(currentContentTab, state.prebuiltGkiEnabled) {
+        if (currentContentTab == FlashContentTab.PrebuiltGki && state.prebuiltGkiEnabled) {
             vm.loadPrebuiltGkiReleases()
         }
     }
@@ -669,7 +681,7 @@ fun FlashScreen(
                     )
                 }
 
-                if (state.prebuiltGkiEnabled) {
+                if (state.prebuiltGkiEnabled && state.isLoggedIn) {
                     item {
                         FlashContentTabs(
                             active = activeContentTab,
@@ -804,6 +816,14 @@ fun FlashScreen(
                                         allowRootActions = rootGranted
                                     )
                                 }
+                            }
+                        } else {
+                            item {
+                                ExpressiveEmptyState(
+                                    title = stringResource(R.string.flash_prebuilt_disabled_title),
+                                    subtitle = stringResource(R.string.flash_prebuilt_disabled_desc),
+                                    icon = Icons.Default.CloudOff
+                                )
                             }
                         }
                     }
@@ -1006,8 +1026,8 @@ fun FlashScreen(
                     selectedPrebuiltReleaseId = releaseId
                     selectedRunId = null
                 }
-                LaunchedEffect(release?.id, state.prebuiltGkiEnabled, state.isLoggedIn) {
-                    if (release != null && state.prebuiltGkiEnabled && state.isLoggedIn) {
+                LaunchedEffect(release?.id, state.prebuiltGkiEnabled) {
+                    if (release != null && state.prebuiltGkiEnabled) {
                         vm.loadPrebuiltGkiAssets(release)
                     }
                 }

--- a/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
@@ -757,6 +757,7 @@ private fun RuntimeModuleRepositoryListContent(
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     bottomPadding: Dp
 ) {
+    val showInitialLoading = refreshing && totalModules == 0 && searchQuery.isBlank()
     Column(
         modifier = Modifier
             .padding(padding)
@@ -771,11 +772,13 @@ private fun RuntimeModuleRepositoryListContent(
             onValueChange = onSearchQueryChange
         )
 
-        if (refreshing) {
+        if (refreshing && !showInitialLoading) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
 
-        if (modules.isEmpty()) {
+        if (showInitialLoading) {
+            ModuleRepositoryInitialLoading()
+        } else if (modules.isEmpty()) {
             RuntimeModuleRepositoryEmptyState(
                 totalModules = totalModules,
                 repositoryCount = repositories.size,
@@ -793,6 +796,28 @@ private fun RuntimeModuleRepositoryListContent(
         }
 
         Spacer(Modifier.height(bottomPadding + 24.dp))
+    }
+}
+
+@Composable
+private fun ModuleRepositoryInitialLoading() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 48.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            LoadingIndicator(Modifier.size(42.dp))
+            Text(
+                text = stringResource(R.string.module_repo_building_list),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
@@ -1537,6 +1562,7 @@ private fun BuildModuleRepositoryListContent(
     bottomPadding: Dp
 ) {
     val context = LocalContext.current
+    val showInitialLoading = refreshing && totalModules == 0 && searchQuery.isBlank()
     Column(
         modifier = Modifier
             .padding(padding)
@@ -1551,11 +1577,13 @@ private fun BuildModuleRepositoryListContent(
             onValueChange = onSearchQueryChange
         )
 
-        if (refreshing) {
+        if (refreshing && !showInitialLoading) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
 
-        if (modules.isEmpty()) {
+        if (showInitialLoading) {
+            ModuleRepositoryInitialLoading()
+        } else if (modules.isEmpty()) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -137,6 +138,11 @@ enum class ModuleRepositoryMode {
     RUNTIME_STANDARD
 }
 
+private data class ModuleListComputation<T>(
+    val items: List<T> = emptyList(),
+    val loading: Boolean = false
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ModuleRepositoryScreen(
@@ -181,12 +187,46 @@ fun ModuleRepositoryScreen(
     val repositoryBackCorner = with(density) {
         (MODULE_REPOSITORY_BACK_MAX_CORNER.toPx() * visualRepositoryBackProgress).toDp()
     }
-    val mergedModules = remember(state.runtimeModuleRepositories) {
-        mergeRuntimeCatalogModules(state.runtimeModuleRepositories)
+    val mergedModulesState by produceState(
+        initialValue = ModuleListComputation<MergedRuntimeCatalogModule>(
+            loading = state.runtimeModuleRepositories.isNotEmpty()
+        ),
+        key1 = state.runtimeModuleRepositories
+    ) {
+        if (state.runtimeModuleRepositories.isEmpty()) {
+            value = ModuleListComputation(items = emptyList(), loading = false)
+            return@produceState
+        }
+        value = ModuleListComputation(loading = true)
+        val merged = withContext(Dispatchers.Default) {
+            mergeRuntimeCatalogModules(state.runtimeModuleRepositories)
+        }
+        value = ModuleListComputation(items = merged, loading = false)
     }
-    val filteredModules = remember(mergedModules, searchQuery) {
-        mergedModules.filter { it.matchesQuery(searchQuery) }
+    val mergedModules = mergedModulesState.items
+    val filteredModulesState by produceState(
+        initialValue = ModuleListComputation<MergedRuntimeCatalogModule>(
+            loading = mergedModulesState.loading
+        ),
+        key1 = mergedModulesState,
+        key2 = searchQuery
+    ) {
+        if (mergedModulesState.loading) {
+            value = ModuleListComputation(loading = true)
+            return@produceState
+        }
+        value = ModuleListComputation(loading = true)
+        val filtered = withContext(Dispatchers.Default) {
+            if (searchQuery.isBlank()) {
+                mergedModules
+            } else {
+                mergedModules.filter { it.matchesQuery(searchQuery) }
+            }
+        }
+        value = ModuleListComputation(items = filtered, loading = false)
     }
+    val filteredModules = filteredModulesState.items
+    val listComputing = mergedModulesState.loading
 
     fun openRepositorySettings() {
         repositoryBackProgress = 0f
@@ -354,6 +394,7 @@ fun ModuleRepositoryScreen(
                 padding = padding,
                 modules = filteredModules,
                 totalModules = mergedModules.size,
+                computing = listComputing,
                 repositories = state.runtimeModuleRepositories,
                 refreshing = state.refreshingRuntimeModuleRepositoryIds.isNotEmpty(),
                 searchQuery = searchQuery,
@@ -476,12 +517,46 @@ private fun BuildModuleRepositoryScreenContent(
     val repositoryBackCorner = with(density) {
         (MODULE_REPOSITORY_BACK_MAX_CORNER.toPx() * visualRepositoryBackProgress).toDp()
     }
-    val mergedModules = remember(state.buildModuleRepositories) {
-        mergeBuildPageCatalogModules(state.buildModuleRepositories)
+    val mergedModulesState by produceState(
+        initialValue = ModuleListComputation<BuildPageMergedCatalogModule>(
+            loading = state.buildModuleRepositories.isNotEmpty()
+        ),
+        key1 = state.buildModuleRepositories
+    ) {
+        if (state.buildModuleRepositories.isEmpty()) {
+            value = ModuleListComputation(items = emptyList(), loading = false)
+            return@produceState
+        }
+        value = ModuleListComputation(loading = true)
+        val merged = withContext(Dispatchers.Default) {
+            mergeBuildPageCatalogModules(state.buildModuleRepositories)
+        }
+        value = ModuleListComputation(items = merged, loading = false)
     }
-    val filteredModules = remember(mergedModules, searchQuery) {
-        mergedModules.filter { it.matchesQuery(searchQuery) }
+    val mergedModules = mergedModulesState.items
+    val filteredModulesState by produceState(
+        initialValue = ModuleListComputation<BuildPageMergedCatalogModule>(
+            loading = mergedModulesState.loading
+        ),
+        key1 = mergedModulesState,
+        key2 = searchQuery
+    ) {
+        if (mergedModulesState.loading) {
+            value = ModuleListComputation(loading = true)
+            return@produceState
+        }
+        value = ModuleListComputation(loading = true)
+        val filtered = withContext(Dispatchers.Default) {
+            if (searchQuery.isBlank()) {
+                mergedModules
+            } else {
+                mergedModules.filter { it.matchesQuery(searchQuery) }
+            }
+        }
+        value = ModuleListComputation(items = filtered, loading = false)
     }
+    val filteredModules = filteredModulesState.items
+    val listComputing = mergedModulesState.loading
     val selectedModules = remember(state.buildConfig.customExternalModules) {
         state.buildConfig.customExternalModules
             .map { it.url.trim().lowercase() to CustomExternalModuleStage.normalize(it.stage) }
@@ -657,6 +732,7 @@ private fun BuildModuleRepositoryScreenContent(
                 padding = padding,
                 modules = filteredModules,
                 totalModules = mergedModules.size,
+                computing = listComputing,
                 repositories = state.buildModuleRepositories,
                 refreshing = state.refreshingBuildModuleRepositoryIds.isNotEmpty(),
                 selectedModules = selectedModules,
@@ -747,6 +823,7 @@ private fun RuntimeModuleRepositoryListContent(
     padding: PaddingValues,
     modules: List<MergedRuntimeCatalogModule>,
     totalModules: Int,
+    computing: Boolean,
     repositories: List<RuntimeModuleRepository>,
     refreshing: Boolean,
     searchQuery: String,
@@ -757,7 +834,7 @@ private fun RuntimeModuleRepositoryListContent(
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     bottomPadding: Dp
 ) {
-    val showInitialLoading = refreshing && totalModules == 0 && searchQuery.isBlank()
+    val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
     Column(
         modifier = Modifier
             .padding(padding)
@@ -1550,6 +1627,7 @@ private fun BuildModuleRepositoryListContent(
     padding: PaddingValues,
     modules: List<BuildPageMergedCatalogModule>,
     totalModules: Int,
+    computing: Boolean,
     repositories: List<ModuleCatalogRepository>,
     refreshing: Boolean,
     selectedModules: Set<Pair<String, String>>,
@@ -1562,7 +1640,7 @@ private fun BuildModuleRepositoryListContent(
     bottomPadding: Dp
 ) {
     val context = LocalContext.current
-    val showInitialLoading = refreshing && totalModules == 0 && searchQuery.isBlank()
+    val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
     Column(
         modifier = Modifier
             .padding(padding)

--- a/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -835,35 +837,48 @@ private fun RuntimeModuleRepositoryListContent(
     bottomPadding: Dp
 ) {
     val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
-    Column(
+    LazyColumn(
         modifier = Modifier
             .padding(padding)
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection)
-            .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        contentPadding = PaddingValues(bottom = bottomPadding + 24.dp)
     ) {
-        CompactModuleSearchField(
-            value = searchQuery,
-            onValueChange = onSearchQueryChange
-        )
+        item(key = "search") {
+            CompactModuleSearchField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange
+            )
+        }
 
         if (refreshing && !showInitialLoading) {
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            item(key = "refreshing") {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
         }
 
         if (showInitialLoading) {
-            ModuleRepositoryInitialLoading()
+            item(key = "initial-loading") {
+                ModuleRepositoryInitialLoading()
+            }
         } else if (modules.isEmpty()) {
-            RuntimeModuleRepositoryEmptyState(
-                totalModules = totalModules,
-                repositoryCount = repositories.size,
-                hasQuery = searchQuery.isNotBlank(),
-                onOpenRepositorySettings = onOpenRepositorySettings
-            )
+            item(key = "empty") {
+                RuntimeModuleRepositoryEmptyState(
+                    totalModules = totalModules,
+                    repositoryCount = repositories.size,
+                    hasQuery = searchQuery.isNotBlank(),
+                    onOpenRepositorySettings = onOpenRepositorySettings
+                )
+            }
         } else {
-            modules.forEach { merged ->
+            items(
+                items = modules,
+                key = { merged ->
+                    "${merged.module.id.trim().lowercase().ifBlank { merged.module.name.trim().lowercase() }}-${merged.sources.joinToString("|")}"
+                }
+            ) { merged ->
                 RuntimeModuleRepositoryListItem(
                     merged = merged,
                     onOpen = { onOpenModule(merged) },
@@ -871,8 +886,6 @@ private fun RuntimeModuleRepositoryListContent(
                 )
             }
         }
-
-        Spacer(Modifier.height(bottomPadding + 24.dp))
     }
 }
 
@@ -1641,58 +1654,71 @@ private fun BuildModuleRepositoryListContent(
 ) {
     val context = LocalContext.current
     val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
-    Column(
+    LazyColumn(
         modifier = Modifier
             .padding(padding)
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection)
-            .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        contentPadding = PaddingValues(bottom = bottomPadding + 24.dp)
     ) {
-        CompactModuleSearchField(
-            value = searchQuery,
-            onValueChange = onSearchQueryChange
-        )
+        item(key = "search") {
+            CompactModuleSearchField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange
+            )
+        }
 
         if (refreshing && !showInitialLoading) {
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            item(key = "refreshing") {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
         }
 
         if (showInitialLoading) {
-            ModuleRepositoryInitialLoading()
+            item(key = "initial-loading") {
+                ModuleRepositoryInitialLoading()
+            }
         } else if (modules.isEmpty()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 28.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Extension,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(38.dp)
-                )
-                Text(
-                    text = when {
-                        searchQuery.isNotBlank() -> context.getString(R.string.module_repo_no_matching)
-                        repositories.isEmpty() -> buildRepoEmptyTitleLabel(context)
-                        totalModules == 0 -> context.getString(R.string.module_repo_refresh_hint)
-                        else -> context.getString(R.string.module_repo_no_display)
-                    },
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                TextButton(onClick = onOpenRepositorySettings) {
-                    Icon(Icons.Default.Dns, null, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(6.dp))
-                    Text(buildRepoManageLabel(context))
+            item(key = "empty") {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 28.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Extension,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(38.dp)
+                    )
+                    Text(
+                        text = when {
+                            searchQuery.isNotBlank() -> context.getString(R.string.module_repo_no_matching)
+                            repositories.isEmpty() -> buildRepoEmptyTitleLabel(context)
+                            totalModules == 0 -> context.getString(R.string.module_repo_refresh_hint)
+                            else -> context.getString(R.string.module_repo_no_display)
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    TextButton(onClick = onOpenRepositorySettings) {
+                        Icon(Icons.Default.Dns, null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(buildRepoManageLabel(context))
+                    }
                 }
             }
         } else {
-            modules.forEach { merged ->
+            items(
+                items = modules,
+                key = { merged ->
+                    merged.module.repoUrl.trim().lowercase()
+                }
+            ) { merged ->
                 val module = merged.module
                 val supportedStages = module.buildNormalizedSupportedStages()
                 val allStagesAdded = supportedStages.all { stage ->
@@ -1812,8 +1838,6 @@ private fun BuildModuleRepositoryListContent(
                 }
             }
         }
-
-        Spacer(Modifier.height(bottomPadding + 24.dp))
     }
 }
 

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -1675,7 +1675,7 @@ private fun openSourceNoticeGroups(): List<OpenSourceNoticeGroup> = listOf(
             OpenSourceNotice("Xiaomichael/kernel_manifest", "Upstream repository license / no SPDX detected", "OnePlus manifest branch source", "https://github.com/Xiaomichael/kernel_manifest"),
             OpenSourceNotice("Xiaomichael/kernel_patches", "Upstream repository license / no SPDX detected", "OnePlus patch source", "https://github.com/Xiaomichael/kernel_patches"),
             OpenSourceNotice("KernelSU", "GPL-3.0", "workflow setup.sh source", "https://github.com/tiann/KernelSU"),
-            OpenSourceNotice("SukiSU Ultra", "GPL-3.0", "kernel setup, ksud, libmagiskboot source", "https://github.com/SukiSU-Ultra/SukiSU-Ultra"),
+            OpenSourceNotice("SukiSU Ultra", "GPL-3.0", "kernel setup, ksud, android_bootimg", "https://github.com/SukiSU-Ultra/SukiSU-Ultra"),
             OpenSourceNotice("ReSukiSU", "GPL-3.0", "workflow setup.sh source", "https://github.com/ReSukiSU/ReSukiSU"),
             OpenSourceNotice("SUSFS", "GPL-2.0", "kernel patches and module integration", "https://gitlab.com/simonpunk/susfs4ksu"),
             OpenSourceNotice("ShirkNeko/susfs4ksu", "GPL-2.0", "GitHub mirror / patch source", "https://github.com/ShirkNeko/susfs4ksu"),

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -398,8 +398,6 @@ object RootUtils {
     fun resolveUserlandKsudPath(context: Context): String? =
         prepareBundledKsudPath(context) ?: embeddedKsudPath(context)
 
-    fun resolveUserlandMagiskbootPath(context: Context): String? = embeddedMagiskbootPath(context)
-
     fun patchAbkLkmBootImage(
         context: Context,
         bootImagePath: String?,
@@ -1594,13 +1592,6 @@ object RootUtils {
     private fun buildKsudShellCommand(ksudPath: String, args: List<String>): String =
         buildShellCommand(buildKsudCommand(ksudPath, args))
 
-    private fun embeddedMagiskbootPath(context: Context? = appContext): String? {
-        val safeContext = context ?: return null
-        return File(safeContext.applicationInfo.nativeLibraryDir, "libmagiskboot.so")
-            .takeIf { it.isFile }
-            ?.absolutePath
-    }
-
     private fun runEmbeddedKsudWithRoot(
         context: Context,
         args: List<String>,
@@ -1692,10 +1683,6 @@ object RootUtils {
     ): List<String> {
         return buildList {
             add("boot-patch")
-            embeddedMagiskbootPath(context)?.let { magiskboot ->
-                add("--magiskboot")
-                add(magiskboot)
-            }
             if (bootImage != null) {
                 add("--boot")
                 add(bootImage.absolutePath)

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -40,7 +40,7 @@ import java.util.UUID
 
 // ── UI State ─────────────────────────────────────────────────────────────────
 
-enum class AuthStep { CHECK_ROOT, LOGIN, FORK_CHECK, READY }
+enum class AuthStep { INTRO, LOGIN, FORK_CHECK }
 
 enum class ManagerAccessState {
     UNKNOWN,
@@ -63,13 +63,15 @@ data class BuildPlanImportPreview(
 )
 
 data class MainUiState(
-    val authStep: AuthStep = AuthStep.LOGIN,
+    val authStep: AuthStep = AuthStep.INTRO,
     val rootGranted: Boolean = false,
     val isLoggedIn: Boolean = false,
     val user: GitHubUser? = null,
     val forkRepo: GitHubRepo? = null,
     val behindBy: Int = 0,
-    val showSyncDialog: Boolean = false,
+    val showSyncPrompt: Boolean = false,
+    val showOobe: Boolean = false,
+    val oobeCompleted: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,
     // Device-flow OAuth
@@ -175,6 +177,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val preparedMirrorArtifacts = mutableMapOf<Long, Set<String>>()
     private val artifactDownloadJobs = mutableMapOf<Long, Job>()
     private var hasCheckedWorkflowEnablementThisLaunch = false
+    private var hasShownInitialOobeThisLaunch = false
+    private var hasRefreshedGitHubSessionThisLaunch = false
     private var buildQueueJob: Job? = null
 
     private val _uiState = MutableStateFlow(MainUiState())
@@ -258,8 +262,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }.collect { (token, name, avatar, autoDl, notify) ->
                 if (!token.isNullOrBlank()) {
                     github.updateToken(token)
-                    val shouldResumeSetup = !_uiState.value.isPollingToken &&
-                        _uiState.value.authStep in setOf(AuthStep.CHECK_ROOT, AuthStep.LOGIN)
                     _uiState.update {
                         it.copy(
                             isLoggedIn = true,
@@ -275,19 +277,23 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             )
                         }
                     }
-                    if (shouldResumeSetup) {
-                        if (name.isNullOrBlank()) {
-                            fetchUserAndContinue()
-                        } else {
-                            advanceStep()
+                    if (!_uiState.value.isPollingToken && !hasRefreshedGitHubSessionThisLaunch) {
+                        hasRefreshedGitHubSessionThisLaunch = true
+                        viewModelScope.launch {
+                            refreshGitHubSessionOnLaunch(name.isNullOrBlank())
                         }
                     }
                 } else {
+                    github.updateToken(null)
                     hasCheckedWorkflowEnablementThisLaunch = false
+                    hasRefreshedGitHubSessionThisLaunch = false
                     _uiState.update {
                         it.copy(
                             isLoggedIn = false,
                             user = null,
+                            forkRepo = null,
+                            behindBy = 0,
+                            showSyncPrompt = false,
                             autoDownload = autoDl,
                             notifyBuild = notify
                         )
@@ -303,6 +309,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         termsAccepted = version >= PreferencesRepository.CURRENT_TERMS_VERSION
                     )
                 }
+            }
+        }
+        viewModelScope.launch {
+            prefs.oobeCompleted.collect { completed ->
+                _uiState.update { state -> state.copy(oobeCompleted = completed) }
             }
         }
         viewModelScope.launch {
@@ -466,7 +477,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun checkRoot() {
         viewModelScope.launch {
-            val shouldAdvance = _uiState.value.authStep != AuthStep.READY
             val granted = RootUtils.isRootAvailable()
             val recommended = detectRecommendedBuildConfig()
             val initialConfig = applyInitialBuildConfigIfNeeded(recommended)
@@ -477,13 +487,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     buildConfig = initialConfig ?: it.buildConfig
                 )
             }
-            if (shouldAdvance) advanceStep()
         }
     }
 
     fun requestRoot() {
         viewModelScope.launch {
-            val shouldAdvance = _uiState.value.authStep != AuthStep.READY
             _uiState.update { it.copy(isLoading = true) }
             val granted = RootUtils.requestRoot()
             val recommended = detectRecommendedBuildConfig()
@@ -496,7 +504,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     buildConfig = initialConfig ?: it.buildConfig
                 )
             }
-            if (shouldAdvance) advanceStep()
         }
     }
 
@@ -1153,18 +1160,56 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         return normalized
     }
 
-    private fun advanceStep() {
+    fun maybeShowInitialOobe() {
         val state = _uiState.value
-        when {
-            !state.isLoggedIn -> _uiState.update { it.copy(authStep = AuthStep.LOGIN) }
-            state.user == null -> {
-                _uiState.update { it.copy(authStep = AuthStep.LOGIN) }
-                viewModelScope.launch { fetchUserAndContinue() }
+        if (!state.termsAccepted || state.oobeCompleted || hasShownInitialOobeThisLaunch) return
+        hasShownInitialOobeThisLaunch = true
+        _uiState.update {
+            it.copy(
+                showOobe = true,
+                authStep = AuthStep.INTRO,
+                error = null
+            )
+        }
+    }
+
+    fun openBuildOobe() {
+        val state = _uiState.value
+        val nextStep = if (state.isLoggedIn && state.user != null) AuthStep.FORK_CHECK else AuthStep.LOGIN
+        _uiState.update {
+            it.copy(
+                showOobe = true,
+                authStep = nextStep,
+                error = null
+            )
+        }
+        if (state.isLoggedIn && state.user == null) {
+            viewModelScope.launch {
+                val user = fetchAuthenticatedUserAndStore() ?: return@launch
+                _uiState.update { it.copy(authStep = AuthStep.FORK_CHECK, user = user, isLoggedIn = true) }
+                checkFork(showSyncPrompt = true, closeOobeWhenReady = true)
             }
-            else -> {
-                _uiState.update { it.copy(authStep = AuthStep.FORK_CHECK) }
-                checkFork()
+        } else if (nextStep == AuthStep.FORK_CHECK) {
+            checkFork(showSyncPrompt = true, closeOobeWhenReady = true)
+        }
+    }
+
+    fun continueOobeToLogin() {
+        _uiState.update {
+            it.copy(
+                showOobe = true,
+                authStep = AuthStep.LOGIN,
+                error = null
+            )
+        }
+    }
+
+    fun skipOobe() {
+        viewModelScope.launch {
+            if (!_uiState.value.oobeCompleted) {
+                prefs.setOobeCompleted(true)
             }
+            closeOobe()
         }
     }
 
@@ -1202,10 +1247,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         when (tokenResp.error) {
                             null -> {
                                 val token = tokenResp.accessToken ?: continue
+                                hasRefreshedGitHubSessionThisLaunch = true
                                 prefs.saveToken(token)
                                 github.updateToken(token)
                                 _uiState.update { it.copy(isPollingToken = false) }
-                                fetchUserAndContinue()
+                                fetchUserAndContinueOobe()
                             }
                             "authorization_pending", "slow_down" -> {
                                 if (tokenResp.error == "slow_down") delay(5000)
@@ -1228,30 +1274,80 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    private suspend fun fetchUserAndContinue() {
+    private suspend fun fetchAuthenticatedUserAndStore(reportError: Boolean = true): GitHubUser? {
         when (val r = github.getAuthenticatedUser()) {
             is Result.Success -> {
                 val user = r.data
                 prefs.saveUsername(user.login)
                 prefs.saveAvatarUrl(user.avatarUrl)
                 _uiState.update { it.copy(user = user, isLoggedIn = true) }
-                advanceStep()
+                return user
             }
-            is Result.Error -> _uiState.update { it.copy(error = r.message) }
-            else -> {}
+            is Result.Error -> if (reportError) {
+                _uiState.update { it.copy(error = r.message) }
+            }
+            Result.Loading -> {}
         }
+        return null
+    }
+
+    private suspend fun refreshGitHubSessionOnLaunch(fetchUser: Boolean) {
+        val user = if (fetchUser || _uiState.value.user == null) {
+            fetchAuthenticatedUserAndStore(reportError = false)
+        } else {
+            _uiState.value.user
+        } ?: return
+        _uiState.update { it.copy(isLoggedIn = true, user = user) }
+        checkFork(showSyncPrompt = true, closeOobeWhenReady = false)
+    }
+
+    private suspend fun fetchUserAndContinueOobe() {
+        val user = fetchAuthenticatedUserAndStore() ?: return
+        _uiState.update {
+            it.copy(
+                user = user,
+                isLoggedIn = true,
+                showOobe = true,
+                authStep = AuthStep.FORK_CHECK
+            )
+        }
+        checkFork(showSyncPrompt = true, closeOobeWhenReady = true)
+    }
+
+    private fun closeOobe() {
+        _uiState.update {
+            it.copy(
+                showOobe = false,
+                authStep = AuthStep.INTRO,
+                deviceCode = null,
+                userCode = null,
+                verificationUri = null,
+                isPollingToken = false,
+                error = null
+            )
+        }
+    }
+
+    private fun completeOobe() {
+        if (!_uiState.value.oobeCompleted) {
+            viewModelScope.launch { prefs.setOobeCompleted(true) }
+        }
+        closeOobe()
     }
 
     fun logout() {
         viewModelScope.launch {
             prefs.clearAuth()
+            github.updateToken(null)
             hasCheckedWorkflowEnablementThisLaunch = false
+            hasRefreshedGitHubSessionThisLaunch = false
             _uiState.update {
                 MainUiState(
                     rootGranted = it.rootGranted,
-                    authStep = AuthStep.LOGIN,
+                    authStep = AuthStep.INTRO,
                     termsLoaded = it.termsLoaded,
                     termsAccepted = it.termsAccepted,
+                    oobeCompleted = it.oobeCompleted,
                     autoDownload = it.autoDownload,
                     notifyBuild = it.notifyBuild,
                     themeMode = it.themeMode,
@@ -1265,6 +1361,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     downloadMirrorBaseUrl = it.downloadMirrorBaseUrl,
                     prebuiltGkiEnabled = it.prebuiltGkiEnabled,
                     predictiveBackEnabled = it.predictiveBackEnabled,
+                    runtimeNavigationEnabled = it.runtimeNavigationEnabled,
+                    webViewDebugEnabled = it.webViewDebugEnabled,
                     runtimeModuleRepositories = it.runtimeModuleRepositories,
                     buildModuleRepositories = it.buildModuleRepositories
                 )
@@ -1274,17 +1372,30 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     // ── Fork Management ───────────────────────────────────────────────────
 
-    fun checkFork() {
+    fun checkFork(showSyncPrompt: Boolean = true, closeOobeWhenReady: Boolean = false) {
         val username = _uiState.value.user?.login ?: return
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    error = null,
+                    authStep = if (it.showOobe) AuthStep.FORK_CHECK else it.authStep
+                )
+            }
             val forkResult = github.getUserFork(
                 BuildConfig.SOURCE_REPO_OWNER, BuildConfig.SOURCE_REPO_NAME, username
             )
             when (forkResult) {
                 is Result.Success -> {
                     if (forkResult.data == null) {
-                        _uiState.update { it.copy(isLoading = false, forkRepo = null) }
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                forkRepo = null,
+                                behindBy = 0,
+                                showSyncPrompt = false
+                            )
+                        }
                     } else {
                         val fork = forkResult.data
                         val upstreamBranch = fork.parent?.defaultBranch ?: fork.defaultBranch
@@ -1302,11 +1413,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                                 isLoading = false,
                                 forkRepo = fork,
                                 behindBy = behind,
-                                showSyncDialog = behind > 0
+                                showSyncPrompt = showSyncPrompt && behind > 0
                             )
                         }
-                        ensureBuildWorkflowEnabled()
-                        if (behind == 0) finishSetup()
+                        onForkContextReady()
+                        if (closeOobeWhenReady) {
+                            completeOobe()
+                        }
                     }
                 }
                 is Result.Error -> _uiState.update { it.copy(isLoading = false, error = forkResult.message) }
@@ -1321,8 +1434,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             when (val r = github.forkRepo(BuildConfig.SOURCE_REPO_OWNER, BuildConfig.SOURCE_REPO_NAME)) {
                 is Result.Success -> {
                     prefs.saveForkRepoName(r.data.name)
-                    _uiState.update { it.copy(isLoading = false, forkRepo = r.data) }
-                    finishSetup()
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            forkRepo = r.data,
+                            behindBy = 0,
+                            showSyncPrompt = false
+                        )
+                    }
+                    onForkContextReady()
+                    completeOobe()
                 }
                 is Result.Error -> _uiState.update { it.copy(isLoading = false, error = r.message) }
                 else -> {}
@@ -1335,11 +1456,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val username = state.user?.login ?: return
         val fork = state.forkRepo ?: return
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, showSyncDialog = false) }
+            _uiState.update { it.copy(isLoading = true, showSyncPrompt = false) }
             when (val r = github.syncFork(username, fork.name, fork.defaultBranch)) {
                 is Result.Success -> {
                     _uiState.update { it.copy(isLoading = false, behindBy = 0) }
-                    finishSetup()
+                    onForkContextReady()
                 }
                 is Result.Error -> _uiState.update { it.copy(isLoading = false, error = r.message) }
                 else -> {}
@@ -1347,13 +1468,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun dismissSyncDialog() {
-        _uiState.update { it.copy(showSyncDialog = false) }
-        finishSetup()
+    fun dismissSyncPrompt() {
+        _uiState.update { it.copy(showSyncPrompt = false) }
     }
 
-    private fun finishSetup() {
-        _uiState.update { it.copy(authStep = AuthStep.READY) }
+    private fun onForkContextReady() {
         loadRecentRuns()
         ensureBuildWorkflowEnabled()
         processBuildQueue()
@@ -1446,6 +1565,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // ── Build ─────────────────────────────────────────────────────────────
 
     fun dispatchBuild(config: KernelBuildConfig) {
+        val state = _uiState.value
+        if (!state.isLoggedIn || state.user == null || state.forkRepo == null) {
+            _uiState.update { it.copy(error = text(R.string.vm_build_login_required)) }
+            return
+        }
         enqueueBuild(config)
     }
 
@@ -1467,7 +1591,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun processBuildQueue() {
         val snapshot = _uiState.value
-        if (!snapshot.isLoggedIn || snapshot.authStep != AuthStep.READY) return
+        if (!snapshot.isLoggedIn || snapshot.user == null || snapshot.forkRepo == null) return
         if (snapshot.buildQueueProcessing || buildQueueJob?.isActive == true) return
         val next = snapshot.buildQueue.firstOrNull { it.status == BuildQueueItemStatus.PENDING } ?: return
         val username = snapshot.user?.login ?: return
@@ -1799,7 +1923,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun loadPrebuiltGkiReleases(force: Boolean = false) {
         val state = _uiState.value
-        if (!state.prebuiltGkiEnabled || !state.isLoggedIn) return
+        if (!state.prebuiltGkiEnabled) return
         if (state.isLoadingPrebuiltGkiReleases || (!force && state.prebuiltGkiReleases.isNotEmpty())) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingPrebuiltGkiReleases = true, error = null) }
@@ -1838,7 +1962,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun loadPrebuiltGkiAssets(release: PrebuiltGkiRelease, force: Boolean = false) {
         val state = _uiState.value
-        if (!state.prebuiltGkiEnabled || !state.isLoggedIn) return
+        if (!state.prebuiltGkiEnabled) return
         if (release.id in state.loadingPrebuiltGkiAssetReleaseIds) return
         if (!force && state.prebuiltGkiAssetsByReleaseId.containsKey(release.id)) return
         viewModelScope.launch {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -759,6 +759,7 @@
     <string name="module_repo_back">Back to module repositories</string>
     <string name="module_repo_no_matching">No matching modules</string>
     <string name="module_repo_no_central">No central repositories yet</string>
+    <string name="module_repo_building_list">Building module list</string>
     <string name="module_repo_refresh_hint">Modules appear after refreshing a central repository</string>
     <string name="module_repo_no_display">No modules to show</string>
     <string name="module_repo_manage_central">Manage central repositories</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -91,9 +91,24 @@
     <string name="sync_action">Sync now</string>
     <string name="sync_behind_commits">Behind by %1$d commits.</string>
     <string name="skip">Skip</string>
+    <string name="oobe_title">Get started with AnyBase Kernel</string>
+    <string name="oobe_desc">This is shown only on first launch. You can skip now and sign in to GitHub later when you actually need builds.</string>
+    <string name="oobe_first_launch">First launch</string>
+    <string name="oobe_build_title">Build features need GitHub</string>
+    <string name="oobe_build_desc">After signing in, ABK can check your fork, trigger workflows, and sync build status.</string>
+    <string name="oobe_build_detail">If you do not need to build right now, skip for now. The Build tab can resume the GitHub sign-in and fork flow later.</string>
+    <string name="oobe_flash_title">The Flash tab can still browse prebuilt GKI</string>
+    <string name="oobe_flash_desc">When signed out, the Flash tab keeps only prebuilt GKI downloads from Releases.</string>
+    <string name="oobe_flash_detail">Workflow artifacts, fork repository access, and Actions records return after sign-in and fork checks complete.</string>
+    <string name="oobe_continue_setup">Continue GitHub setup</string>
+    <string name="oobe_skip_for_now">Skip for now</string>
 
     <!-- Build -->
     <string name="build_title">Build Kernel</string>
+    <string name="build_login_required_title">Sign in to GitHub before building</string>
+    <string name="build_login_required_desc">ABK no longer forces GitHub sign-in at startup. Enter OOBE here when you are ready to build.</string>
+    <string name="build_fork_required_title">Fork setup is still required</string>
+    <string name="build_fork_required_desc">This account is already signed in, but there is no usable fork yet. Continue OOBE so ABK can check and finish the fork setup.</string>
     <string name="build_target_title">Build target</string>
     <string name="build_target_desc">Choose the standard GKI build or a OnePlus/Oplus device build.</string>
     <string name="build_target_gki">GKI</string>
@@ -329,6 +344,8 @@
     <string name="flash_loading_release">Fetching releases</string>
     <string name="flash_empty_prebuilt_title">No prebuilt GKI releases</string>
     <string name="flash_empty_prebuilt_desc">No browsable releases were found in this repository.</string>
+    <string name="flash_prebuilt_disabled_title">Prebuilt GKI is disabled</string>
+    <string name="flash_prebuilt_disabled_desc">When signed out, the Flash tab keeps only prebuilt GKI downloads. Re-enable this feature in Settings.</string>
     <string name="flash_workflow_unavailable">Workflow record unavailable</string>
     <string name="flash_workflow_unavailable_desc">This workflow artifact was refreshed or deleted.</string>
     <string name="flash_loading_prebuilt">Fetching prebuilt GKI for %1$s</string>
@@ -874,6 +891,7 @@
     <string name="vm_runtime_module_uninstall_unsupported">This module does not support uninstall</string>
     <string name="vm_runtime_module_default_name">Module</string>
     <string name="vm_auth_failed">Authorization failed: %1$s</string>
+    <string name="vm_build_login_required">Finish GitHub sign-in and fork setup before submitting a build.</string>
     <string name="vm_workflow_still_disabled">Workflow is still not enabled. Current state: %1$s</string>
     <string name="vm_workflow_dispatch_failed">Failed to trigger workflow: %1$s</string>
     <string name="vm_build_dispatch_no_result">Build dispatch returned no result</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -856,7 +856,6 @@
     <string name="root_patch_enable_adb_debug_desc">Force USB debugging and disable adb authentication. Enable only when needed.</string>
     <string name="root_patch_warn_no_lkm">No bundled LKM matches the current variant and KMI. Select a local .ko file.</string>
     <string name="root_patch_warn_no_ksud">This APK does not include an executable bundled SukiSU-Ultra ksud, so it can not patch boot.img without root. Use an APK with bundled ksud, or grant root and continue.</string>
-    <string name="root_patch_warn_no_magiskboot">This APK does not include an executable bundled magiskboot, so it can not unpack boot.img without root. Use an APK with bundled magiskboot, or grant root and continue.</string>
     <string name="root_patch_processing">Processing</string>
     <string name="root_patch_next">Next</string>
     <string name="root_patch_result">Patch result</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -815,7 +815,6 @@
     <string name="root_patch_enable_adb_debug_desc">Принудительно разрешить USB-отладку и отключить аутентификацию adb. Включайте только при необходимости.</string>
     <string name="root_patch_warn_no_lkm">Для текущего варианта и KMI нет встроенного LKM. Выберите локальный .ko-файл.</string>
     <string name="root_patch_warn_no_ksud">В этот APK не встроен исполняемый SukiSU-Ultra ksud, поэтому пропатчить boot.img без root нельзя. Используйте APK со встроенным ksud или выдайте root.</string>
-    <string name="root_patch_warn_no_magiskboot">В этот APK не встроен исполняемый magiskboot, поэтому распаковать boot.img без root нельзя. Используйте APK со встроенным magiskboot или выдайте root.</string>
     <string name="root_patch_processing">Обработка</string>
     <string name="root_patch_next">Далее</string>
     <string name="root_patch_result">Результат патча</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -759,6 +759,7 @@
     <string name="module_repo_back">返回模块仓库</string>
     <string name="module_repo_no_matching">没有匹配的模块</string>
     <string name="module_repo_no_central">还没有中央仓库</string>
+    <string name="module_repo_building_list">正在构建模块列表</string>
     <string name="module_repo_refresh_hint">刷新中央仓库后会显示模块</string>
     <string name="module_repo_no_display">没有可显示的模块</string>
     <string name="module_repo_manage_central">管理中央仓库</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,9 +91,24 @@
     <string name="sync_action">立即同步</string>
     <string name="sync_behind_commits">落后 %1$d 个提交。</string>
     <string name="skip">跳过</string>
+    <string name="oobe_title">开始使用 AnyBase Kernel</string>
+    <string name="oobe_desc">首次启动只展示一次。你可以先跳过，之后需要构建时再登录 GitHub。</string>
+    <string name="oobe_first_launch">首次启动</string>
+    <string name="oobe_build_title">构建功能需要 GitHub</string>
+    <string name="oobe_build_desc">登录后 ABK 才能检查 fork、触发工作流并同步构建状态。</string>
+    <string name="oobe_build_detail">如果暂时不构建内核，可以先跳过。切到构建页时再继续登录和 fork 流程。</string>
+    <string name="oobe_flash_title">刷写页可直接浏览预编译 GKI</string>
+    <string name="oobe_flash_desc">未登录时，刷写页只保留 Release 里的预编译 GKI 下载。</string>
+    <string name="oobe_flash_detail">工作流构建产物、fork 仓库和 Actions 记录会在登录并完成 fork 检查后恢复可用。</string>
+    <string name="oobe_continue_setup">继续配置 GitHub</string>
+    <string name="oobe_skip_for_now">暂时跳过</string>
 
     <!-- Build -->
     <string name="build_title">构建内核</string>
+    <string name="build_login_required_title">登录 GitHub 后才能构建</string>
+    <string name="build_login_required_desc">ABK 现在不会在启动时强制登录。需要构建内核时，再进入 OOBE 完成 GitHub 授权即可。</string>
+    <string name="build_fork_required_title">还需要完成 fork 配置</string>
+    <string name="build_fork_required_desc">当前账号已登录，但还没有可用的 fork 仓库。继续 OOBE 后，ABK 会检查并引导完成 fork。</string>
     <string name="build_target_title">构建目标</string>
     <string name="build_target_desc">选择标准 GKI 构建或 OnePlus/Oplus 机型构建。</string>
     <string name="build_target_gki">GKI</string>
@@ -329,6 +344,8 @@
     <string name="flash_loading_release">正在获取 Release</string>
     <string name="flash_empty_prebuilt_title">暂无预编译 GKI Release</string>
     <string name="flash_empty_prebuilt_desc">本仓库 Release 中暂未发现可浏览的版本。</string>
+    <string name="flash_prebuilt_disabled_title">预编译 GKI 已关闭</string>
+    <string name="flash_prebuilt_disabled_desc">未登录状态下，刷写页只保留预编译 GKI 下载。可在设置里重新开启该功能。</string>
     <string name="flash_workflow_unavailable">工作流记录不可用</string>
     <string name="flash_workflow_unavailable_desc">该工作流产物已被刷新或删除。</string>
     <string name="flash_loading_prebuilt">正在获取 %1$s 的预编译 GKI</string>
@@ -874,6 +891,7 @@
     <string name="vm_runtime_module_uninstall_unsupported">当前模块不支持卸载</string>
     <string name="vm_runtime_module_default_name">模块</string>
     <string name="vm_auth_failed">授权失败: %1$s</string>
+    <string name="vm_build_login_required">请先完成 GitHub 登录和 fork 配置，再提交构建。</string>
     <string name="vm_workflow_still_disabled">工作流仍未启用，当前状态: %1$s</string>
     <string name="vm_workflow_dispatch_failed">触发工作流失败: %1$s</string>
     <string name="vm_build_dispatch_no_result">触发构建未返回结果</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -856,7 +856,6 @@
     <string name="root_patch_enable_adb_debug_desc">强制允许 USB 调试并取消 adb 认证，非必要请勿开启。</string>
     <string name="root_patch_warn_no_lkm">当前变体和 KMI 没有内置 LKM，请选择本地 .ko 文件。</string>
     <string name="root_patch_warn_no_ksud">当前 APK 未包含可执行的内置 SukiSU-Ultra ksud，无法无 Root 修补 boot.img。请使用带内置 ksud 的 APK，或授予 Root 后继续。</string>
-    <string name="root_patch_warn_no_magiskboot">当前 APK 未包含可执行的内置 magiskboot，无法无 Root 解包 boot.img。请使用带内置 magiskboot 的 APK，或授予 Root 后继续。</string>
     <string name="root_patch_processing">处理中</string>
     <string name="root_patch_next">下一步</string>
     <string name="root_patch_result">修补结果</string>

--- a/app_dev/strings.xml
+++ b/app_dev/strings.xml
@@ -759,6 +759,7 @@
     <string name="module_repo_back">返回模块仓库</string>
     <string name="module_repo_no_matching">没有匹配的模块</string>
     <string name="module_repo_no_central">还没有中央仓库</string>
+    <string name="module_repo_building_list">正在构建模块列表</string>
     <string name="module_repo_refresh_hint">刷新中央仓库后会显示模块</string>
     <string name="module_repo_no_display">没有可显示的模块</string>
     <string name="module_repo_manage_central">管理中央仓库</string>

--- a/app_dev/strings.xml
+++ b/app_dev/strings.xml
@@ -91,9 +91,24 @@
     <string name="sync_action">立即同步</string>
     <string name="sync_behind_commits">落后 %1$d 个提交。</string>
     <string name="skip">跳过</string>
+    <string name="oobe_title">开始使用 AnyBase Kernel</string>
+    <string name="oobe_desc">首次启动只展示一次。你可以先跳过，之后需要构建时再登录 GitHub。</string>
+    <string name="oobe_first_launch">首次启动</string>
+    <string name="oobe_build_title">构建功能需要 GitHub</string>
+    <string name="oobe_build_desc">登录后 ABK 才能检查 fork、触发工作流并同步构建状态。</string>
+    <string name="oobe_build_detail">如果暂时不构建内核，可以先跳过。切到构建页时再继续登录和 fork 流程。</string>
+    <string name="oobe_flash_title">刷写页可直接浏览预编译 GKI</string>
+    <string name="oobe_flash_desc">未登录时，刷写页只保留 Release 里的预编译 GKI 下载。</string>
+    <string name="oobe_flash_detail">工作流构建产物、fork 仓库和 Actions 记录会在登录并完成 fork 检查后恢复可用。</string>
+    <string name="oobe_continue_setup">继续配置 GitHub</string>
+    <string name="oobe_skip_for_now">暂时跳过</string>
 
     <!-- Build -->
     <string name="build_title">构建内核</string>
+    <string name="build_login_required_title">登录 GitHub 后才能构建</string>
+    <string name="build_login_required_desc">ABK 现在不会在启动时强制登录。需要构建内核时，再进入 OOBE 完成 GitHub 授权即可。</string>
+    <string name="build_fork_required_title">还需要完成 fork 配置</string>
+    <string name="build_fork_required_desc">当前账号已登录，但还没有可用的 fork 仓库。继续 OOBE 后，ABK 会检查并引导完成 fork。</string>
     <string name="build_target_title">构建目标</string>
     <string name="build_target_desc">选择标准 GKI 构建或 OnePlus/Oplus 机型构建。</string>
     <string name="build_target_gki">GKI</string>
@@ -329,6 +344,8 @@
     <string name="flash_loading_release">正在获取 Release</string>
     <string name="flash_empty_prebuilt_title">暂无预编译 GKI Release</string>
     <string name="flash_empty_prebuilt_desc">本仓库 Release 中暂未发现可浏览的版本。</string>
+    <string name="flash_prebuilt_disabled_title">预编译 GKI 已关闭</string>
+    <string name="flash_prebuilt_disabled_desc">未登录状态下，刷写页只保留预编译 GKI 下载。可在设置里重新开启该功能。</string>
     <string name="flash_workflow_unavailable">工作流记录不可用</string>
     <string name="flash_workflow_unavailable_desc">该工作流产物已被刷新或删除。</string>
     <string name="flash_loading_prebuilt">正在获取 %1$s 的预编译 GKI</string>
@@ -874,6 +891,7 @@
     <string name="vm_runtime_module_uninstall_unsupported">当前模块不支持卸载</string>
     <string name="vm_runtime_module_default_name">模块</string>
     <string name="vm_auth_failed">授权失败: %1$s</string>
+    <string name="vm_build_login_required">请先完成 GitHub 登录和 fork 配置，再提交构建。</string>
     <string name="vm_workflow_still_disabled">工作流仍未启用，当前状态: %1$s</string>
     <string name="vm_workflow_dispatch_failed">触发工作流失败: %1$s</string>
     <string name="vm_build_dispatch_no_result">触发构建未返回结果</string>


### PR DESCRIPTION
This pull request removes the use of upstream `magiskboot` binaries from the build process and updates the documentation and workflows to reflect that `ksud` now uses the in-process `android_bootimg` crate. Additionally, it introduces UI improvements in the Android app, such as a new OOBE (Out-Of-Box Experience) screen and a sync prompt dialog, and simplifies GitHub API client handling in the repository code.

**Build and Workflow Changes:**

* Removed all logic for downloading and embedding upstream `magiskboot` binaries (`libmagiskboot.so`) in both `build-abk-app.yml` and `build-abk-app-dev.yml` workflows; updated summary output to clarify that `magiskboot` is no longer used and that `ksud` uses the `bootimg` crate instead. [[1]](diffhunk://#diff-09f0156b3ecedb7260ad3ad333c8ad5046534af04f3a60f710e306785e027dd2L74-L86) [[2]](diffhunk://#diff-09f0156b3ecedb7260ad3ad333c8ad5046534af04f3a60f710e306785e027dd2L180-L191) [[3]](diffhunk://#diff-09f0156b3ecedb7260ad3ad333c8ad5046534af04f3a60f710e306785e027dd2L226-L232) [[4]](diffhunk://#diff-09f0156b3ecedb7260ad3ad333c8ad5046534af04f3a60f710e306785e027dd2L276-R246) [[5]](diffhunk://#diff-ff1f1fcdf2a758e226cce5cd984c14f1cdff4dc5f05d339f5a74cf8cb5093a1bL76-L88) [[6]](diffhunk://#diff-ff1f1fcdf2a758e226cce5cd984c14f1cdff4dc5f05d339f5a74cf8cb5093a1bL182-L193) [[7]](diffhunk://#diff-ff1f1fcdf2a758e226cce5cd984c14f1cdff4dc5f05d339f5a74cf8cb5093a1bL228-L234) [[8]](diffhunk://#diff-ff1f1fcdf2a758e226cce5cd984c14f1cdff4dc5f05d339f5a74cf8cb5093a1bL278-R246)
* Updated `THIRD_PARTY_NOTICES.md` to clarify that the APK no longer bundles or requires `libmagiskboot.so` and that `ksud` patches boot images via the `android_bootimg` crate.
* Updated the tracked upstream ref for SukiSU-Ultra in the main build workflow.
* Added `app_dev/**` to the workflow trigger paths to ensure changes in the development app directory trigger builds.

**Android App UI and Logic Improvements:**

* Added a new OOBE (Out-Of-Box Experience) screen and logic to display it when appropriate, and introduced a `SyncPromptDialog` to prompt users to sync their fork if it is behind. [[1]](diffhunk://#diff-e808bda970756eaffc9afc6b0d81490a5d0ec56a8c57b1281a7dc0559c0e4356R115-R130) [[2]](diffhunk://#diff-e808bda970756eaffc9afc6b0d81490a5d0ec56a8c57b1281a7dc0559c0e4356L142-R176) [[3]](diffhunk://#diff-e808bda970756eaffc9afc6b0d81490a5d0ec56a8c57b1281a7dc0559c0e4356R190-R217)
* Refactored imports and removed unused `AuthGateScreen` and `AuthStep` references from `MainActivity.kt`.

**GitHub API Client Handling:**

* Simplified the `GitHubRepository` to always initialize the API service, allowing for an optional token, and removed nullable checks for the API service in all repository methods. [[1]](diffhunk://#diff-c2b9342f67b1a4581e2b0a415a704baf883589c24020bb44bddf3af8e13ee3e5L36-R36) [[2]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL30-R38) [[3]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL196-R196) [[4]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL207-R207) [[5]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL223-R223) [[6]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL238-R238) [[7]](diffhunk://#diff-b37e2270d4710bc7a63927f200079c3b0cfe2665f971b4fb8f922605af5ca23cL251-R251)