### PR TITLE
Add yml and app add_defconfig

### DIFF
--- a/.github/workflows/all-managers-full-feature-matrix.yml
+++ b/.github/workflows/all-managers-full-feature-matrix.yml
@@ -285,7 +285,6 @@ jobs:
       use_rekernel: ${{ inputs.use_rekernel }}
       supp_op: ${{ inputs.supp_op }}
       virtualization_support: ${{ inputs.virtualization_support }}
-      use_custom_external_modules: ${{ inputs.use_custom_external_modules }}
       custom_external_modules: ${{ inputs.custom_external_modules }}
       upload_aux_artifacts: ${{ inputs.upload_aux_artifacts }}
       trigger_release: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,10 +103,6 @@ on:
         default: ""
 
       # ==================== 自定义外部模块 ====================
-      use_custom_external_modules:
-        required: false
-        type: boolean
-        default: false
       custom_external_modules:
         required: false
         type: string
@@ -195,7 +191,7 @@ jobs:
           echo "KPM 密码      : ${{ inputs.kpm_password && '已自定义' || '默认' }}"
           echo "Re-Kernel     : ${{ inputs.use_rekernel }}"
           echo "虚拟化支持   : ${{ inputs.virtualization_support }}"
-          echo "自定义注入    : ${{ inputs.use_custom_external_modules }}"
+          echo "自定义注入    : ${{ inputs.custom_external_modules }}"
           echo "Stock Config  : 自动检测 config/stock_defconfig"
           echo "========================================"
 
@@ -626,7 +622,7 @@ jobs:
           git clone https://github.com/Numbersf/Action-Build.git --depth=1
 
       - name: 克隆自定义外部模块
-        if: inputs.use_custom_external_modules
+        if: inputs.custom_external_modules != ''
         env:
           CUSTOM_EXTERNAL_MODULES: ${{ inputs.custom_external_modules }}
         run: |
@@ -2537,7 +2533,7 @@ jobs:
           grep -q '^CONFIG_REKERNEL_NETWORK=y$' "$DEFCONFIG" || echo "CONFIG_REKERNEL_NETWORK=y" >> "$DEFCONFIG"
 
       - name: 执行自定义外部模块 (after_patch)
-        if: inputs.use_custom_external_modules
+        if: inputs.custom_external_modules != ''
         env:
           CUSTOM_EXTERNAL_MODULE_STAGE: after_patch
           ABK_BUILD_ANDROID_VERSION: ${{ inputs.android_version }}
@@ -2751,7 +2747,7 @@ jobs:
           fi
 
       - name: 执行自定义外部模块 (before_build)
-        if: inputs.use_custom_external_modules
+        if: inputs.custom_external_modules != ''
         env:
           CUSTOM_EXTERNAL_MODULE_STAGE: before_build
           ABK_BUILD_ANDROID_VERSION: ${{ inputs.android_version }}
@@ -3816,7 +3812,7 @@ jobs:
           PY
 
       - name: 校验 ABK 管理器桥接
-        if: inputs.use_custom_external_modules && inputs.ksu_variant != 'None'
+        if: inputs.custom_external_modules != '' && inputs.ksu_variant != 'None'
         working-directory: ${{ env.KERNEL_ROOT }}
         run: |
           set -euo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ on:
       custom_ref:
         required: false
         type: string
+      add_defconfig:
+        required: false
+        type: string
       version:
         required: false
         type: string
@@ -179,6 +182,7 @@ jobs:
           echo "KSU 分支      : $effective_ksu_branch"
           echo "管理器包名    : ${{ inputs.manager_package || 'app/signing/abk-manager-cert.env' }}"
           echo "构建时间      : ${{ inputs.build_time }}"
+          echo "额外内核参数   : $(printf "%s" "${{ inputs.add_defconfig }}" | tr '\n' ' ')"
           echo "SUSFS 状态    : ${{ inputs.enable_susfs }}"
           echo "ZRAM 增强     : $effective_use_zram"
           echo "ZRAM 完整算法 : $effective_zram_full_algo"
@@ -2594,6 +2598,40 @@ jobs:
       - name: 配置内核选项
         working-directory: ${{ env.KERNEL_ROOT }}
         run: |
+          ensure_defconfig_value() {
+            local cfg="$1"
+            local value="$2"
+            local line="${cfg}=${value}"
+
+            if [ "$value" = "n" ]; then
+              line="# ${cfg} is not set"
+            fi
+
+            if grep -qxF "$line" "$DEFCONFIG"; then
+              return 0
+            fi
+
+            if grep -Eq "^${cfg}=|^# ${cfg} is not set$" "$DEFCONFIG"; then
+              sed -i -E "s|^${cfg}=.*|${line}|; s|^# ${cfg} is not set$|${line}|" "$DEFCONFIG"
+            else
+              echo "$line" >> "$DEFCONFIG"
+            fi
+          }
+ 
+          if [ "${{ inputs.add_defconfig }}" != "" ]; then
+            echo "set custom kernel config:"
+            echo "${{ inputs.add_defconfig }}" | tr ' ' '\n' | while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            if echo "$line" | grep -Eq "^CONFIG_[A-Za-z0-9_]+=.+$"; then
+              cfg=$(echo "$line" | cut -d= -f1)
+              val=$(echo "$line" | cut -d= -f2-)
+              echo "$cfg=$val"
+              ensure_defconfig_value "$cfg" "$val"
+              continue
+            fi
+            done
+          fi
+
           if [ "${{ inputs.ksu_variant }}" != "None" ]; then
             cat >> "$DEFCONFIG" << 'EOF'
           CONFIG_KSU=y

--- a/.github/workflows/get-manager.yml
+++ b/.github/workflows/get-manager.yml
@@ -105,16 +105,11 @@ jobs:
 
           VAR=$([[ "${{ inputs.kernelsu_variant }}" == "SukiSU" ]] && echo 700 || echo 200)
 
-          cd KernelSU
-          # 如果是 commit SHA，则直接 fetch 该 commit
+          cd KernelSU         
           if [[ "$BRANCH" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "Detected commit SHA, fetching it..."
-              git fetch origin "$BRANCH" --depth=1
-              git checkout "$BRANCH"
-          else
-              # 普通分支或 tag
-              git checkout "$BRANCH" || git checkout -b "$BRANCH" "origin/$BRANCH" 
+              git fetch origin "$BRANCH"
           fi
+          git checkout "$BRANCH" || git checkout -b "$BRANCH" "origin/$BRANCH" 
 
           # 计算KSU版本号
           KSU_GIT_VERSION=$(git rev-list --count HEAD)

--- a/.github/workflows/kernel-custom.yml
+++ b/.github/workflows/kernel-custom.yml
@@ -163,11 +163,6 @@ on:
         default: ""
 
       # ==================== 自定义外部模块 ====================
-      use_custom_external_modules:
-        description: "启用自定义外部模块注入"
-        required: false
-        type: boolean
-        default: false
       custom_external_modules:
         description: "自定义外部模块（链接;阶段，用 | 分隔多个，如 https://github.com/user/mod;after_patch|https://github.com/user/mod2;before_build）"
         required: false
@@ -203,7 +198,6 @@ jobs:
       zram_full_algo: ${{ inputs.zram_full_algo || false }}
       zram_extra_algos: ${{ inputs.zram_extra_algos || '' }}
       kpm_password: ${{ inputs.kpm_password || '' }}
-      use_custom_external_modules: ${{ inputs.use_custom_external_modules || false }}
       custom_external_modules: ${{ inputs.custom_external_modules || '' }}
 
   get-ksu-manager:

--- a/.github/workflows/kernel-custom.yml
+++ b/.github/workflows/kernel-custom.yml
@@ -73,6 +73,10 @@ on:
         description: "自定义引用 (仅在KSU分支为'Custom(自定义)'时使用)"
         required: false
         type: string
+      add_defconfig:
+        description: "自定义内核参数"
+        required: false
+        type: string
       version:
         description: "自定义版本名 (可选)"
         required: false
@@ -183,6 +187,7 @@ jobs:
       ksu_variant: ${{ inputs.kernelsu_variant }}
       ksu_branch: ${{ inputs.kernelsu_branch }}
       custom_ref: ${{ inputs.custom_ref || '' }}
+      add_defconfig: ${{ inputs.add_defconfig || '' }}
       version: ${{ inputs.version || '' }}
       build_time: ${{ inputs.build_time || '' }}
       use_zram: ${{ inputs.use_zram }}

--- a/.github/workflows/kernel-full-feature-matrix.yml
+++ b/.github/workflows/kernel-full-feature-matrix.yml
@@ -113,11 +113,6 @@ on:
           - "123"
           - "345"
         default: "off"
-      use_custom_external_modules:
-        description: "启用自定义外部模块注入"
-        required: false
-        type: boolean
-        default: false
       custom_external_modules:
         description: "自定义外部模块（repo;stage|repo;stage，stage=after_patch/before_build）"
         required: false
@@ -205,10 +200,6 @@ on:
         required: false
         type: string
         default: "off"
-      use_custom_external_modules:
-        required: false
-        type: boolean
-        default: false
       custom_external_modules:
         required: false
         type: string
@@ -254,7 +245,6 @@ jobs:
           MATRIX_KPM_PASSWORD: ${{ inputs.kpm_password || '' }}
           MATRIX_USE_REKERNEL: ${{ inputs.use_rekernel }}
           MATRIX_SUPP_OP: ${{ inputs.supp_op }}
-          MATRIX_USE_CUSTOM_EXTERNAL_MODULES: ${{ inputs.use_custom_external_modules }}
           MATRIX_CUSTOM_EXTERNAL_MODULES: ${{ inputs.custom_external_modules || '' }}
           MATRIX_UPLOAD_AUX_ARTIFACTS: ${{ inputs.upload_aux_artifacts }}
         run: |
@@ -353,7 +343,6 @@ jobs:
               summary.write(f"- KPM 密码: {'已自定义' if os.environ.get('MATRIX_KPM_PASSWORD', '') else '默认'}\n")
               summary.write(f"- Re-Kernel: {env_enabled('MATRIX_USE_REKERNEL')}\n")
               summary.write(f"- 一加 8E: {env_enabled('MATRIX_SUPP_OP')}\n")
-              summary.write(f"- 自定义外部模块: {env_enabled('MATRIX_USE_CUSTOM_EXTERNAL_MODULES')}\n")
               summary.write(f"- 自定义外部模块参数: {env_value('MATRIX_CUSTOM_EXTERNAL_MODULES')}\n")
               summary.write(f"- 上传辅助产物: {env_enabled('MATRIX_UPLOAD_AUX_ARTIFACTS')}\n")
               summary.write("- Android16/6.12: ZRAM off\n")
@@ -397,7 +386,6 @@ jobs:
       zram_full_algo: ${{ inputs.zram_full_algo && matrix.kernel_version != '6.12' }}
       zram_extra_algos: ${{ inputs.zram_extra_algos || '' }}
       kpm_password: ${{ inputs.kpm_password || '' }}
-      use_custom_external_modules: ${{ inputs.use_custom_external_modules }}
       custom_external_modules: ${{ inputs.custom_external_modules || '' }}
       upload_aux_artifacts: ${{ inputs.upload_aux_artifacts }}
 
@@ -429,7 +417,6 @@ jobs:
       USE_KPM: ${{ inputs.use_kpm }}
       USE_REKERNEL: ${{ inputs.use_rekernel }}
       SUPP_OP: ${{ inputs.supp_op }}
-      USE_CUSTOM_EXTERNAL_MODULES: ${{ inputs.use_custom_external_modules }}
       CUSTOM_EXTERNAL_MODULES: ${{ inputs.custom_external_modules || '' }}
       USE_NTSYNC: ${{ inputs.use_ntsync }}
       USE_NETWORKING: ${{ inputs.use_networking }}
@@ -494,7 +481,6 @@ jobs:
               --arg kpm_password "$kpm_password_label" \
               --arg use_rekernel "$USE_REKERNEL" \
               --arg supp_op "$SUPP_OP" \
-              --arg use_custom_external_modules "$USE_CUSTOM_EXTERNAL_MODULES" \
               --arg custom_external_modules "$custom_modules_label" \
               --arg use_ntsync "$USE_NTSYNC" \
               --arg use_networking "$USE_NETWORKING" \
@@ -516,7 +502,6 @@ jobs:
                 kpm_password: $kpm_password,
                 use_rekernel: $use_rekernel,
                 supp_op: $supp_op,
-                use_custom_external_modules: $use_custom_external_modules,
                 custom_external_modules: $custom_external_modules,
                 use_ntsync: $use_ntsync,
                 use_networking: $use_networking,
@@ -553,7 +538,6 @@ jobs:
             echo "- KPM: ${USE_KPM}"
             echo "- Re-Kernel: ${USE_REKERNEL}"
             echo "- 一加 8E: ${SUPP_OP}"
-            echo "- 自定义注入: ${USE_CUSTOM_EXTERNAL_MODULES}"
             echo "- 自定义注入参数列表: ${custom_modules_label}"
             echo "- 上传辅助产物: ${UPLOAD_AUX_ARTIFACTS}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-existing-full-feature-run.yml
+++ b/.github/workflows/release-existing-full-feature-run.yml
@@ -152,7 +152,6 @@ jobs:
           kpm_password="$(metadata_value kpm_password "默认")"
           use_rekernel="$(metadata_value use_rekernel "true")"
           supp_op="$(metadata_value supp_op "true")"
-          use_custom_external_modules="$(metadata_value use_custom_external_modules "false")"
           custom_external_modules="$(metadata_value custom_external_modules "无")"
           use_ntsync="$(metadata_value use_ntsync "true")"
           use_networking="$(metadata_value use_networking "true")"
@@ -269,7 +268,6 @@ jobs:
           | Re-Kernel | $use_rekernel |
           | 虚拟化支持 | $virtualization_support |
           | 一加 8E 支持 | $supp_op |
-          | 自定义注入 | $use_custom_external_modules |
           | 自定义注入参数列表 | $custom_external_modules |
 
           > Android 16 / 6.12 构建会自动关闭 ZRAM 增强与 ZRAM 完整算法；虚拟化支持在 6.12 上使用开关模式。

--- a/app/src/main/java/com/abk/kernel/data/model/KernelSupport.kt
+++ b/app/src/main/java/com/abk/kernel/data/model/KernelSupport.kt
@@ -293,6 +293,7 @@ object KernelSupport {
             customRef = if (isOnePlus) "" else config.customRef.trim(),
             version = if (isOnePlus) "" else config.version,
             buildTime = if (isOnePlus) "" else config.buildTime,
+            addDefconfig = if (isOnePlus) "" else config.addDefconfig,
             useZram = if (isOnePlus) false else config.useZram,
             useDdk = if (isOnePlus) false else config.useDdk,
             useNtsync = if (isOnePlus) false else config.useNtsync,

--- a/app/src/main/java/com/abk/kernel/data/model/Models.kt
+++ b/app/src/main/java/com/abk/kernel/data/model/Models.kt
@@ -117,6 +117,7 @@ data class BuildParameterSummary(
     val ksuVariant: String = "",
     val ksuBranch: String = "",
     val buildTime: String = "",
+    val addDefconfig: String = "",
     val susfsEnabled: String = "",
     val zramEnabled: String = "",
     val zramFullAlgo: String = "",
@@ -422,6 +423,7 @@ data class KernelBuildConfig(
     val customRef: String = "",
     val version: String = "",
     val buildTime: String = "",
+    val addDefconfig: String = "",
     val useZram: Boolean = false,
     val useBbg: Boolean = false,
     val useDdk: Boolean = false,
@@ -476,6 +478,7 @@ data class AbkRuntimeBuildInfo(
     @SerializedName("kernelsu_branch") val kernelsuBranch: String = "",
     val version: String = "",
     @SerializedName("build_time") val buildTime: String = "",
+    @SerializedName("add_defconfig") val addDefconfig: String = "",
     @SerializedName("virtualization_support") val virtualizationSupport: String = "",
     @SerializedName("zram_extra_algos") val zramExtraAlgos: String = "",
     val features: Map<String, Boolean> = emptyMap()

--- a/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
@@ -1334,6 +1334,13 @@ fun BuildScreen(
                     singleLine = true
                 )
                 ConfigPreviewText(buildTimePreview)
+                OutlinedTextField(
+                    value = config.addDefconfig,
+                    onValueChange = { vm.updateBuildConfig(config.copy(addDefconfig = it)) },
+                    label = { Text(stringResource(R.string.build_add_defconfig)) },
+                    placeholder = { Text(stringResource(R.string.build_add_defconfig_placeholder)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
             }
 

--- a/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
@@ -1532,6 +1532,7 @@ private fun ParameterSummarySections(summary: BuildParameterSummary) {
         ParameterRow(stringResource(R.string.build_sub_level), summary.subLevel)
         ParameterRow(stringResource(R.string.runtime_patch_level), summary.osPatchLevel)
         ParameterRow(stringResource(R.string.flash_build_time), summary.buildTime)
+        ParameterRow(stringResource(R.string.flash_add_defconfig), summary.addDefconfig)
     }
     ParameterSection("KernelSU") {
         ParameterRow(stringResource(R.string.flash_ksu_variant), summary.ksuVariant)
@@ -1659,6 +1660,7 @@ private fun parsePrebuiltGkiParameterSummary(release: PrebuiltGkiRelease): Build
         ksuVariant = values["ksuVariant"].orEmpty(),
         ksuBranch = values["ksuBranch"].orEmpty(),
         buildTime = values["buildTime"].orEmpty(),
+        addDefconfig = values["addDefconfig"].orEmpty(),
         susfsEnabled = values["susfsEnabled"].orEmpty(),
         zramEnabled = values["zramEnabled"].orEmpty(),
         zramFullAlgo = values["zramFullAlgo"].orEmpty(),
@@ -1724,6 +1726,7 @@ private fun normalizeReleaseParameterLabel(label: String): String? {
         compact.contains("ksu变体") -> "ksuVariant"
         compact.contains("ksu分支") -> "ksuBranch"
         compact.contains("构建时间") -> "buildTime"
+        compact.contains("额外内核参数") -> "addDefconfig"
         compact.contains("susfs状态") -> "susfsEnabled"
         compact.contains("zram增强") -> "zramEnabled"
         compact.contains("zram完整算法") -> "zramFullAlgo"

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -4374,6 +4374,7 @@ internal fun encodeBuildPlanPayload(
     writer.writeVarInt(config.toBuildPlanFeatureMask())
     writer.writeString(config.version)
     writer.writeString(config.buildTime)
+    writer.writeString(config.addDefconfig)
     writer.writeString(config.zramExtraAlgos)
     writer.writeString(config.kpmPassword)
     writer.writeString(config.customRef)
@@ -4456,6 +4457,7 @@ internal fun decodeBuildPlanPayload(
     val featureMask = reader.readVarInt()
     val versionName = reader.readString()
     val buildTime = reader.readString()
+    val addDefconfig = reader.readString()
     val zramExtraAlgos = reader.readString()
     val kpmPassword = reader.readString()
     val customRef = if (version >= BUILD_PLAN_CUSTOM_REF_VERSION) {
@@ -4480,6 +4482,7 @@ internal fun decodeBuildPlanPayload(
         kernelsuBranch = ksuBranch,
         version = versionName,
         buildTime = buildTime,
+        addDefconfig = addDefconfig,
         useZram = featureMask.hasBuildPlanFlag(0),
         useBbg = featureMask.hasBuildPlanFlag(1),
         useDdk = featureMask.hasBuildPlanFlag(2),
@@ -4654,6 +4657,7 @@ private const val SUMMARY_LABEL_PATCH_LEVEL = "\u8865\u4e01\u7ea7\u522b"
 private const val SUMMARY_LABEL_KSU_VARIANT = "ksu\u53d8\u4f53"
 private const val SUMMARY_LABEL_KSU_BRANCH = "ksu\u5206\u652f"
 private const val SUMMARY_LABEL_BUILD_TIME = "\u6784\u5efa\u65f6\u95f4"
+private const val SUMMARY_LABEL_ADD_DEFCONFIG = "\u989d\u5916\u5185\u6838\u53c2\u6570"
 private const val SUMMARY_LABEL_SUSFS_STATUS = "susfs\u72b6\u6001"
 private const val SUMMARY_LABEL_ZRAM = "zram\u589e\u5f3a"
 private const val SUMMARY_LABEL_ZRAM_FULL_ALGO = "zram\u5b8c\u6574\u7b97\u6cd5"
@@ -4723,6 +4727,7 @@ internal fun parseBuildParameterSummary(
         ksuVariant = values["ksuVariant"].orEmpty(),
         ksuBranch = values["ksuBranch"].orEmpty(),
         buildTime = values["buildTime"].orEmpty(),
+        add_defconfig = values["addDefconfig"].orEmpty(),
         susfsEnabled = values["susfsEnabled"].orEmpty(),
         zramEnabled = values["zramEnabled"].orEmpty(),
         zramFullAlgo = values["zramFullAlgo"].orEmpty(),
@@ -4758,6 +4763,7 @@ private fun normalizeBuildSummaryLabel(label: String): String? {
         compact.contains(SUMMARY_LABEL_KSU_VARIANT) -> "ksuVariant"
         compact.contains(SUMMARY_LABEL_KSU_BRANCH) -> "ksuBranch"
         compact.contains(SUMMARY_LABEL_BUILD_TIME) -> "buildTime"
+        compact.contains(SUMMARY_LABEL_ADD_DEFCONFIG) -> "addDefconfig"
         compact.contains(SUMMARY_LABEL_SUSFS_STATUS) -> "susfsEnabled"
         compact.contains(SUMMARY_LABEL_ZRAM) -> "zramEnabled"
         compact.contains(SUMMARY_LABEL_ZRAM_FULL_ALGO) -> "zramFullAlgo"
@@ -5051,6 +5057,7 @@ internal fun KernelBuildConfig.toInputMap(): Map<String, String> {
         "kernelsu_branch" to config.kernelsuBranch,
         "version" to config.version,
         "build_time" to config.buildTime,
+        "add_defconfig" to config.addDefconfig,
         "use_zram" to config.useZram.toString(),
         "use_bbg" to config.useBbg.toString(),
         "use_ddk" to config.useDdk.toString(),

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -4727,7 +4727,7 @@ internal fun parseBuildParameterSummary(
         ksuVariant = values["ksuVariant"].orEmpty(),
         ksuBranch = values["ksuBranch"].orEmpty(),
         buildTime = values["buildTime"].orEmpty(),
-        add_defconfig = values["addDefconfig"].orEmpty(),
+        addDefconfig = values["addDefconfig"].orEmpty(),
         susfsEnabled = values["susfsEnabled"].orEmpty(),
         zramEnabled = values["zramEnabled"].orEmpty(),
         zramFullAlgo = values["zramFullAlgo"].orEmpty(),

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -5064,7 +5064,6 @@ internal fun KernelBuildConfig.toInputMap(): Map<String, String> {
         "zram_extra_algos" to config.zramExtraAlgos,
         "kpm_password" to config.kpmPassword,
         "virtualization_support" to config.virtualizationSupport,
-        "use_custom_external_modules" to config.useCustomExternalModules.toString(),
         "custom_ref" to if (config.kernelsuBranch == KSU_BRANCH_CUSTOM) {
             config.customRef.trim()
         } else {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -214,6 +214,8 @@
     <string name="build_custom_version_optional">Custom version name (optional)</string>
     <string name="build_custom_time_optional">Custom build time (optional)</string>
     <string name="build_time_placeholder">Empty/N = current UTC time</string>
+    <string name="build_add_defconfig">Extra kernel parameters (optional)</string>
+    <string name="build_add_defconfig_placeholder">e.g. CONFIG_TMPFS_XATTR=y CONFIG_USER_NS=n</string>
     <string name="build_add_queue">Add to queue</string>
     <string name="build_queue_title">Build queue</string>
     <string name="build_plan_library">Plan library</string>
@@ -378,6 +380,7 @@
     <string name="flash_unknown">Unknown</string>
     <string name="flash_version_params">Version parameters</string>
     <string name="flash_build_time">Build time</string>
+    <string name="flash_add_defconfig">Add defconfig</string>
     <string name="flash_ksu_variant">KSU variant</string>
     <string name="flash_ksu_branch">KSU branch</string>
     <string name="flash_susfs_status">SUSFS status</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -177,6 +177,8 @@
     <string name="build_custom_version_optional">Своё название версии (необязательно)</string>
     <string name="build_custom_time_optional">Своё время сборки (необязательно)</string>
     <string name="build_time_placeholder">Пусто/N = текущее UTC</string>
+    <string name="build_add_defconfig">Дополнительные параметры ядра (необязательно)</string>
+    <string name="build_add_defconfig_placeholder">например: CONFIG_TMPFS_XATTR=y CONFIG_USER_NS=n</string>
     <string name="build_add_queue">Добавить в очередь</string>
     <string name="build_queue_title">Очередь сборок</string>
     <string name="build_plan_library">Библиотека пресетов</string>
@@ -338,6 +340,7 @@
     <string name="flash_unknown">Неизвестно</string>
     <string name="flash_version_params">Параметры версии</string>
     <string name="flash_build_time">Время сборки</string>
+    <string name="flash_add_defconfig">Добавить defconfig</string>
     <string name="flash_ksu_variant">Вариант KSU</string>
     <string name="flash_ksu_branch">Ветка KSU</string>
     <string name="flash_susfs_status">Статус SUSFS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="build_custom_version_optional">自定义版本名 (可选)</string>
     <string name="build_custom_time_optional">自定义构建时间 (可选)</string>
     <string name="build_time_placeholder">留空/N=当前 UTC 时间</string>
+    <string name="build_add_defconfig">额外内核参数 (可选)</string>
+    <string name="build_add_defconfig_placeholder">如: CONFIG_TMPFS_XATTR=y CONFIG_USER_NS=n</string>
     <string name="build_add_queue">加入队列</string>
     <string name="build_queue_title">构建队列</string>
     <string name="build_plan_library">方案库</string>
@@ -378,6 +380,7 @@
     <string name="flash_unknown">未知</string>
     <string name="flash_version_params">版本参数</string>
     <string name="flash_build_time">构建时间</string>
+    <string name="flash_add_defconfig">额外内核参数</string>
     <string name="flash_ksu_variant">KSU 变体</string>
     <string name="flash_ksu_branch">KSU 分支</string>
     <string name="flash_susfs_status">SUSFS 状态</string>

--- a/app/src/test/java/com/abk/kernel/viewmodel/BuildPlanLogicTest.kt
+++ b/app/src/test/java/com/abk/kernel/viewmodel/BuildPlanLogicTest.kt
@@ -29,6 +29,7 @@ class BuildPlanLogicTest {
                 customRef = "feature:5",
                 version = "test-build",
                 buildTime = "Sun Dec 01 08:10:00 UTC 2024",
+                addDefconfig = "",
                 useZram = true,
                 useBbg = true,
                 useDdk = true,
@@ -63,6 +64,7 @@ class BuildPlanLogicTest {
         assertEquals(config.customRef, decoded.config.customRef)
         assertEquals(config.version, decoded.config.version)
         assertEquals(config.buildTime, decoded.config.buildTime)
+        assertEquals(config.addDefconfig, decoded.config.addDefconfig)
         assertEquals(config.zramExtraAlgos, decoded.config.zramExtraAlgos)
         assertEquals(config.kpmPassword, decoded.config.kpmPassword)
         assertEquals(config.virtualizationSupport, decoded.config.virtualizationSupport)

--- a/app/src/test/java/com/abk/kernel/viewmodel/BuildPlanLogicTest.kt
+++ b/app/src/test/java/com/abk/kernel/viewmodel/BuildPlanLogicTest.kt
@@ -131,7 +131,6 @@ class BuildPlanLogicTest {
         assertEquals("true", inputs["use_ddk"])
         assertEquals(KSU_BRANCH_CUSTOM, inputs["kernelsu_branch"])
         assertEquals("main:5", inputs["custom_ref"])
-        assertEquals("true", inputs["use_custom_external_modules"])
         assertEquals(
             "https://github.com/example/a.git;after_patch|https://github.com/example/b.git;before_build",
             inputs["custom_external_modules"]

--- a/app/src/test/java/com/abk/kernel/viewmodel/BuildSummaryParserTest.kt
+++ b/app/src/test/java/com/abk/kernel/viewmodel/BuildSummaryParserTest.kt
@@ -62,6 +62,7 @@ class BuildSummaryParserTest {
         assertEquals("ReSukiSU", summary.ksuVariant)
         assertEquals("Stable(标准)", summary.ksuBranch)
         assertEquals("无", summary.buildTime)
+        assertEquals("无", summary.addDefconfig)
         assertEquals("true", summary.networkingEnabled)
         assertEquals("已设置", summary.kpmPassword)
         assertEquals("678", summary.virtualizationSupport)

--- a/app_dev/strings.xml
+++ b/app_dev/strings.xml
@@ -199,6 +199,8 @@
     <string name="build_custom_version_optional">自定义版本名 (可选)</string>
     <string name="build_custom_time_optional">自定义构建时间 (可选)</string>
     <string name="build_time_placeholder">留空/N=当前 UTC 时间</string>
+    <string name="build_add_defconfig">额外内核参数 (可选)</string>
+    <string name="build_add_defconfig_placeholder">如: CONFIG_TMPFS_XATTR=y CONFIG_USER_NS=n</string>
     <string name="build_add_queue">加入队列</string>
     <string name="build_queue_title">构建队列</string>
     <string name="build_plan_library">方案库</string>
@@ -361,6 +363,7 @@
     <string name="flash_unknown">未知</string>
     <string name="flash_version_params">版本参数</string>
     <string name="flash_build_time">构建时间</string>
+    <string name="flash_add_defconfig">额外内核参数</string>
     <string name="flash_ksu_variant">KSU 变体</string>
     <string name="flash_ksu_branch">KSU 分支</string>
     <string name="flash_susfs_status">SUSFS 状态</string>


### PR DESCRIPTION
This PR removes the use_custom_external_modules field to avoid redundant Action inputs and adds add_defconfig to support injecting extra kernel parameters, improving the extensibility of the kernel build process. 
GitHub Actions imposes a limit of 25 inputs for workflow_dispatch，so need delete use_custom_external_modules