### PR TITLE
fix(ci): resolve KSU Latest and manager from Release workflow on main HEAD

### DIFF
--- a/.github/scripts/download-manager-from-actions.sh
+++ b/.github/scripts/download-manager-from-actions.sh
@@ -89,7 +89,10 @@ try_download_nightly_run() {
   echo "Downloaded manager from ${REPO}@${KSU_SHA} (run ${run_id}, source ${MANAGER_RUN_SOURCE}) via nightly.link"
 }
 
-run_id="$(ksu_find_manager_run_id "$REPO" "$KSU_SHA")"
+if ! ksu_find_manager_run_id "$REPO" "$KSU_SHA"; then
+  exit 1
+fi
+run_id="${KSU_MANAGER_RUN_ID}"
 if [ "${MANAGER_RUN_FALLBACK_MAIN:-0}" = "1" ]; then
   echo "::notice::Manager APK from latest successful build-manager on main (KSU ref was ${KSU_SHA})" >&2
 fi

--- a/.github/scripts/download-manager-from-actions.sh
+++ b/.github/scripts/download-manager-from-actions.sh
@@ -7,6 +7,10 @@ VARIANT_DIR="${3:?output dir required}"
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=resolve-ksu-ref.sh
+source "${SCRIPT_DIR}/resolve-ksu-ref.sh"
+
 # Artifact zip names on nightly.link match actions/upload-artifact names + ".zip".
 nightly_artifact_zip() {
   case "$REPO" in
@@ -26,47 +30,6 @@ manager_artifact_name() {
   esac
 }
 
-github_api_curl() {
-  local auth=()
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
-  fi
-  curl -fsSL "${auth[@]}" -H "Accept: application/vnd.github+json" "$@"
-}
-
-workflow_run_id_from_json() {
-  printf '%s' "$1" | jq -r '.workflow_runs[0].id // empty'
-}
-
-find_build_manager_run_id() {
-  local sha="$1"
-  local run_json run_id
-  if ! [[ "$sha" =~ ^[A-Fa-f0-9]{40}$ ]]; then
-    echo "::error::Manager download requires a 40-char commit SHA, got: ${sha}" >&2
-    return 1
-  fi
-  run_json="$(github_api_curl \
-    "https://api.github.com/repos/${REPO}/actions/workflows/build-manager.yml/runs?head_sha=${sha}&status=success&per_page=1")"
-  run_id="$(workflow_run_id_from_json "$run_json")"
-  if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
-    MANAGER_RUN_FALLBACK_MAIN=0
-    printf '%s\n' "$run_id"
-    return 0
-  fi
-
-  echo "::notice::No successful build-manager run for ${REPO} at head_sha=${sha}; falling back to latest successful run on main" >&2
-  run_json="$(github_api_curl \
-    "https://api.github.com/repos/${REPO}/actions/workflows/build-manager.yml/runs?branch=main&status=success&per_page=1")"
-  run_id="$(workflow_run_id_from_json "$run_json")"
-  if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-    echo "::error::No successful build-manager run for ${REPO} on main either" >&2
-    printf '%s' "$run_json" | jq -r '.message // empty' >&2 || true
-    return 1
-  fi
-  MANAGER_RUN_FALLBACK_MAIN=1
-  printf '%s\n' "$run_id"
-}
-
 extract_apk_from_zip() {
   local tmp_zip="$1"
   unzip -o "$tmp_zip" -d "$VARIANT_DIR"
@@ -80,14 +43,15 @@ extract_apk_from_zip() {
 
 try_download_artifact_api() {
   local run_id="$1"
-  local artifact_name tmp_zip artifact_id artifacts_json artifact_url
+  local artifact_name tmp_zip artifact_id artifacts_json
 
   if [ -z "${GITHUB_TOKEN:-}" ]; then
     return 1
   fi
 
   artifact_name="$(manager_artifact_name)"
-  artifacts_json="$(github_api_curl \
+  KSU_API_REPO="$REPO"
+  artifacts_json="$(ksu_github_api_curl \
     "https://api.github.com/repos/${REPO}/actions/runs/${run_id}/artifacts")"
   artifact_id="$(printf '%s' "$artifacts_json" | jq -r --arg name "$artifact_name" '
     (.artifacts[] | select(.name == $name) | .id) // empty')"
@@ -98,14 +62,14 @@ try_download_artifact_api() {
 
   mkdir -p "$VARIANT_DIR"
   tmp_zip="$(mktemp "${TMPDIR:-/tmp}/manager-XXXXXX.zip")"
-  if ! github_api_curl -L \
+  if ! ksu_github_api_curl -L \
     "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
     -o "$tmp_zip"; then
     rm -f "$tmp_zip"
     return 1
   fi
   extract_apk_from_zip "$tmp_zip"
-  echo "Downloaded manager from ${REPO}@${KSU_SHA} (run ${run_id}) via Actions API"
+  echo "Downloaded manager from ${REPO}@${KSU_SHA} (run ${run_id}, source ${MANAGER_RUN_SOURCE}) via Actions API"
 }
 
 try_download_nightly_run() {
@@ -116,21 +80,20 @@ try_download_nightly_run() {
   mkdir -p "$VARIANT_DIR"
   tmp_zip="$(mktemp "${TMPDIR:-/tmp}/manager-XXXXXX.zip")"
 
-  echo "Downloading manager via nightly.link (run ${run_id}, sha ${KSU_SHA}): ${url}"
+  echo "Downloading manager via nightly.link (run ${run_id}, sha ${KSU_SHA}, source ${MANAGER_RUN_SOURCE}): ${url}"
   if ! curl -fsSL -o "$tmp_zip" "$url"; then
     rm -f "$tmp_zip"
     return 1
   fi
   extract_apk_from_zip "$tmp_zip"
-  echo "Downloaded manager from ${REPO}@${KSU_SHA} (run ${run_id}) via nightly.link"
+  echo "Downloaded manager from ${REPO}@${KSU_SHA} (run ${run_id}, source ${MANAGER_RUN_SOURCE}) via nightly.link"
 }
 
-MANAGER_RUN_FALLBACK_MAIN=0
-run_id="$(find_build_manager_run_id "$KSU_SHA")"
-if [ "${MANAGER_RUN_FALLBACK_MAIN}" = "1" ]; then
-  echo "::notice::Manager APK from latest successful build-manager on main (KSU ref was ${KSU_SHA})"
+run_id="$(ksu_find_manager_run_id "$REPO" "$KSU_SHA")"
+if [ "${MANAGER_RUN_FALLBACK_MAIN:-0}" = "1" ]; then
+  echo "::notice::Manager APK from latest successful build-manager on main (KSU ref was ${KSU_SHA})" >&2
 fi
-echo "build-manager run for ${REPO}@${KSU_SHA}: https://github.com/${REPO}/actions/runs/${run_id}"
+echo "Manager workflow run for ${REPO}@${KSU_SHA} (source=${MANAGER_RUN_SOURCE}): https://github.com/${REPO}/actions/runs/${run_id}"
 
 if [ -n "${GITHUB_REPOSITORY:-}" ] && [ "$REPO" = "$GITHUB_REPOSITORY" ]; then
   if try_download_artifact_api "$run_id"; then
@@ -148,5 +111,5 @@ if try_download_nightly_run "$run_id"; then
   exit 0
 fi
 
-echo "::error::Failed to download manager for ${REPO}@${KSU_SHA} (run ${run_id}) via API and nightly.link" >&2
+echo "::error::Failed to download manager for ${REPO}@${KSU_SHA} (run ${run_id}, source ${MANAGER_RUN_SOURCE}) via API and nightly.link" >&2
 exit 1

--- a/.github/scripts/resolve-ksu-ref.sh
+++ b/.github/scripts/resolve-ksu-ref.sh
@@ -1,4 +1,155 @@
 #!/usr/bin/env bash
+# KernelSU ref resolution for GKI builds. Manager CI helpers below are also sourced by
+# download-manager-from-actions.sh — keep them free of required env vars until main runs.
+
+KSU_BUILD_MANAGER_WORKFLOW="build-manager.yml"
+KSU_RELEASE_WORKFLOW="release.yml"
+
+ksu_github_api_curl() {
+  local repo="${KSU_API_REPO:-}"
+  local auth=()
+  if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ "$repo" = "$GITHUB_REPOSITORY" ]; then
+    auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+  curl -fsSL "${auth[@]}" -H "Accept: application/vnd.github+json" "$@"
+}
+
+ksu_workflow_run_id_for_head_sha() {
+  local repo="$1"
+  local workflow_file="$2"
+  local sha="$3"
+  local run_json run_id
+
+  KSU_API_REPO="$repo"
+  run_json="$(ksu_github_api_curl \
+    "https://api.github.com/repos/${repo}/actions/workflows/${workflow_file}/runs?head_sha=${sha}&status=success&per_page=1")"
+  run_id="$(printf '%s' "$run_json" | jq -r '.workflow_runs[0].id // empty')"
+  if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+    printf '%s\n' "$run_id"
+    return 0
+  fi
+  return 1
+}
+
+ksu_workflow_run_id_for_branch() {
+  local repo="$1"
+  local workflow_file="$2"
+  local branch="$3"
+  local run_json run_id
+
+  KSU_API_REPO="$repo"
+  run_json="$(ksu_github_api_curl \
+    "https://api.github.com/repos/${repo}/actions/workflows/${workflow_file}/runs?branch=${branch}&status=success&per_page=1")"
+  run_id="$(printf '%s' "$run_json" | jq -r '.workflow_runs[0].id // empty')"
+  if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+    printf '%s\n' "$run_id"
+    return 0
+  fi
+  return 1
+}
+
+ksu_main_head_sha() {
+  local repo="$1"
+  local sha
+
+  KSU_API_REPO="$repo"
+  sha="$(ksu_github_api_curl "https://api.github.com/repos/${repo}/git/ref/heads/main" \
+    | jq -r '.object.sha // empty')"
+  if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+    return 1
+  fi
+  printf '%s\n' "$sha"
+}
+
+ksu_latest_build_manager_sha_on_branch() {
+  local repo="$1"
+  local branch="$2"
+  local nabe="${3:-1}"
+  local index=$((nabe - 1))
+  local sha
+
+  KSU_API_REPO="$repo"
+  sha="$(ksu_github_api_curl \
+    "https://api.github.com/repos/${repo}/actions/workflows/${KSU_BUILD_MANAGER_WORKFLOW}/runs?status=success&branch=${branch}&per_page=${nabe}" \
+    | jq -r --argjson idx "$index" '.workflow_runs[$idx].head_sha // empty')"
+  if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+    return 1
+  fi
+  printf '%s\n' "$sha"
+}
+
+# Sets KSU_LATEST_SOURCE (main-head-release | main-head-build-manager | main-fallback).
+ksu_resolve_latest_sha() {
+  local repo="$1"
+  local main_head sha
+
+  main_head="$(ksu_main_head_sha "$repo")" || {
+    echo "::error::Failed to read main HEAD for ${repo}" >&2
+    return 1
+  }
+
+  if ksu_workflow_run_id_for_head_sha "$repo" "$KSU_RELEASE_WORKFLOW" "$main_head" >/dev/null; then
+    KSU_LATEST_SOURCE="main-head-release"
+    printf '%s\n' "$main_head"
+    return 0
+  fi
+
+  if ksu_workflow_run_id_for_head_sha "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "$main_head" >/dev/null; then
+    KSU_LATEST_SOURCE="main-head-build-manager"
+    printf '%s\n' "$main_head"
+    return 0
+  fi
+
+  sha="$(ksu_latest_build_manager_sha_on_branch "$repo" "main" 1)" || {
+    echo "::error::No successful Release or build-manager run on ${repo}@main (required for Latest)" >&2
+    return 1
+  }
+  KSU_LATEST_SOURCE="main-fallback"
+  printf '%s\n' "$sha"
+}
+
+# Sets MANAGER_RUN_SOURCE and MANAGER_RUN_FALLBACK_MAIN; prints workflow run id.
+ksu_find_manager_run_id() {
+  local repo="$1"
+  local sha="$2"
+  local run_id
+
+  if ! [[ "$sha" =~ ^[A-Fa-f0-9]{40}$ ]]; then
+    echo "::error::Manager download requires a 40-char commit SHA, got: ${sha}" >&2
+    return 1
+  fi
+
+  MANAGER_RUN_SOURCE=""
+  MANAGER_RUN_FALLBACK_MAIN=0
+
+  if run_id="$(ksu_workflow_run_id_for_head_sha "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "$sha")"; then
+    MANAGER_RUN_SOURCE="build-manager"
+    printf '%s\n' "$run_id"
+    return 0
+  fi
+
+  if run_id="$(ksu_workflow_run_id_for_head_sha "$repo" "$KSU_RELEASE_WORKFLOW" "$sha")"; then
+    MANAGER_RUN_SOURCE="release"
+    printf '%s\n' "$run_id"
+    return 0
+  fi
+
+  echo "::notice::No successful build-manager or Release run for ${repo} at head_sha=${sha}; falling back to latest successful build-manager on main" >&2
+  if run_id="$(ksu_workflow_run_id_for_branch "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "main")"; then
+    MANAGER_RUN_SOURCE="fallback-main"
+    MANAGER_RUN_FALLBACK_MAIN=1
+    printf '%s\n' "$run_id"
+    return 0
+  fi
+
+  echo "::error::No successful build-manager run for ${repo} on main either" >&2
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  return 0 2>/dev/null || true
+fi
+
 set -euo pipefail
 
 KSU_VARIANT="${KSU_VARIANT:?KSU_VARIANT is required}"
@@ -28,27 +179,7 @@ get_success_action_sha() {
   local repo="$1"
   local branch="$2"
   local nabe="$3"
-  local index=$((nabe - 1))
-  local auth=()
-  if [ -n "${GITHUB_TOKEN:-}" ] && [ "$repo" = "${GITHUB_REPOSITORY:-}" ]; then
-    auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
-  fi
-  curl -fsSL "${auth[@]}" \
-    -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/${repo}/actions/workflows/build-manager.yml/runs?status=success&branch=${branch}&per_page=${nabe}" \
-    | jq -r --argjson idx "$index" '.workflow_runs[$idx].head_sha'
-}
-
-latest_sha_from_build_manager() {
-  local repo="$1"
-  local branch="$2"
-  local sha
-  sha="$(get_success_action_sha "$repo" "$branch" 1)"
-  if [ -z "$sha" ] || [ "$sha" = "null" ]; then
-    echo "::error::No successful build-manager run on ${repo}@${branch} (required for Latest)" >&2
-    return 1
-  fi
-  printf '%s\n' "$sha"
+  ksu_latest_build_manager_sha_on_branch "$repo" "$branch" "$nabe" || true
 }
 
 check_ref() {
@@ -72,30 +203,27 @@ check_ref() {
 }
 
 resolve_latest() {
-  local repo primary secondary source_branch sha
+  local repo source_branch sha
 
   case "$KSU_VARIANT" in
     Official)
       repo="tiann/KernelSU"
-      source_branch="main"
-      sha="$(latest_sha_from_build_manager "$repo" "$source_branch")"
       ;;
     SukiSU)
       # GKI builds use main; builtin is for OnePlus only (oneplus-build.yml, not resolve-ksu-ref).
       repo="$SUKISU_REPO"
-      source_branch="main"
-      sha="$(latest_sha_from_build_manager "$repo" "$source_branch")"
       ;;
     ReSukiSU)
       repo="ReSukiSU/ReSukiSU"
-      source_branch="main"
-      sha="$(latest_sha_from_build_manager "$repo" "$source_branch")"
       ;;
     *)
       echo "::error::Unknown KSU variant for Latest: ${KSU_VARIANT}" >&2
       exit 1
       ;;
   esac
+
+  source_branch="main"
+  sha="$(ksu_resolve_latest_sha "$repo")"
 
   RESOLVED_KSU_REPO="$repo"
   RESOLVED_KSU_SOURCE_BRANCH="$source_branch"
@@ -187,5 +315,5 @@ emit_env "RESOLVED_KSU_REPO" "${RESOLVED_KSU_REPO:-}"
 
 echo "KSU branch: ${KSU_BRANCH} -> ${BRANCH}"
 if [ "$KSU_BRANCH" = "Latest(最新)" ]; then
-  echo "Latest resolved: repo=${RESOLVED_KSU_REPO} branch=${RESOLVED_KSU_SOURCE_BRANCH} sha=${RESOLVED_KSU_SHA}"
+  echo "Latest resolved: repo=${RESOLVED_KSU_REPO} branch=${RESOLVED_KSU_SOURCE_BRANCH} sha=${RESOLVED_KSU_SHA} source=${KSU_LATEST_SOURCE:-unknown}"
 fi

--- a/.github/scripts/resolve-ksu-ref.sh
+++ b/.github/scripts/resolve-ksu-ref.sh
@@ -78,10 +78,13 @@ ksu_latest_build_manager_sha_on_branch() {
   printf '%s\n' "$sha"
 }
 
-# Sets KSU_LATEST_SOURCE (main-head-release | main-head-build-manager | main-fallback).
+# Sets KSU_RESOLVED_LATEST_SHA and KSU_LATEST_SOURCE (no stdout; safe under set -u).
 ksu_resolve_latest_sha() {
   local repo="$1"
   local main_head sha
+
+  KSU_RESOLVED_LATEST_SHA=""
+  KSU_LATEST_SOURCE=""
 
   main_head="$(ksu_main_head_sha "$repo")" || {
     echo "::error::Failed to read main HEAD for ${repo}" >&2
@@ -90,13 +93,13 @@ ksu_resolve_latest_sha() {
 
   if ksu_workflow_run_id_for_head_sha "$repo" "$KSU_RELEASE_WORKFLOW" "$main_head" >/dev/null; then
     KSU_LATEST_SOURCE="main-head-release"
-    printf '%s\n' "$main_head"
+    KSU_RESOLVED_LATEST_SHA="$main_head"
     return 0
   fi
 
   if ksu_workflow_run_id_for_head_sha "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "$main_head" >/dev/null; then
     KSU_LATEST_SOURCE="main-head-build-manager"
-    printf '%s\n' "$main_head"
+    KSU_RESOLVED_LATEST_SHA="$main_head"
     return 0
   fi
 
@@ -105,10 +108,11 @@ ksu_resolve_latest_sha() {
     return 1
   }
   KSU_LATEST_SOURCE="main-fallback"
-  printf '%s\n' "$sha"
+  KSU_RESOLVED_LATEST_SHA="$sha"
+  return 0
 }
 
-# Sets MANAGER_RUN_SOURCE and MANAGER_RUN_FALLBACK_MAIN; prints workflow run id.
+# Sets KSU_MANAGER_RUN_ID, MANAGER_RUN_SOURCE, and MANAGER_RUN_FALLBACK_MAIN (no stdout; safe under set -u).
 ksu_find_manager_run_id() {
   local repo="$1"
   local sha="$2"
@@ -119,18 +123,19 @@ ksu_find_manager_run_id() {
     return 1
   fi
 
+  KSU_MANAGER_RUN_ID=""
   MANAGER_RUN_SOURCE=""
   MANAGER_RUN_FALLBACK_MAIN=0
 
   if run_id="$(ksu_workflow_run_id_for_head_sha "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "$sha")"; then
     MANAGER_RUN_SOURCE="build-manager"
-    printf '%s\n' "$run_id"
+    KSU_MANAGER_RUN_ID="$run_id"
     return 0
   fi
 
   if run_id="$(ksu_workflow_run_id_for_head_sha "$repo" "$KSU_RELEASE_WORKFLOW" "$sha")"; then
     MANAGER_RUN_SOURCE="release"
-    printf '%s\n' "$run_id"
+    KSU_MANAGER_RUN_ID="$run_id"
     return 0
   fi
 
@@ -138,7 +143,7 @@ ksu_find_manager_run_id() {
   if run_id="$(ksu_workflow_run_id_for_branch "$repo" "$KSU_BUILD_MANAGER_WORKFLOW" "main")"; then
     MANAGER_RUN_SOURCE="fallback-main"
     MANAGER_RUN_FALLBACK_MAIN=1
-    printf '%s\n' "$run_id"
+    KSU_MANAGER_RUN_ID="$run_id"
     return 0
   fi
 
@@ -223,11 +228,13 @@ resolve_latest() {
   esac
 
   source_branch="main"
-  sha="$(ksu_resolve_latest_sha "$repo")"
+  if ! ksu_resolve_latest_sha "$repo"; then
+    return 1
+  fi
 
   RESOLVED_KSU_REPO="$repo"
   RESOLVED_KSU_SOURCE_BRANCH="$source_branch"
-  RESOLVED_KSU_SHA="$sha"
+  RESOLVED_KSU_SHA="$KSU_RESOLVED_LATEST_SHA"
 }
 
 OFFICIAL_CUSTOM_REF=""
@@ -315,5 +322,6 @@ emit_env "RESOLVED_KSU_REPO" "${RESOLVED_KSU_REPO:-}"
 
 echo "KSU branch: ${KSU_BRANCH} -> ${BRANCH}"
 if [ "$KSU_BRANCH" = "Latest(最新)" ]; then
+  emit_env "KSU_LATEST_SOURCE" "${KSU_LATEST_SOURCE:-unknown}"
   echo "Latest resolved: repo=${RESOLVED_KSU_REPO} branch=${RESOLVED_KSU_SOURCE_BRANCH} sha=${RESOLVED_KSU_SHA} source=${KSU_LATEST_SOURCE:-unknown}"
 fi

--- a/README-EN.md
+++ b/README-EN.md
@@ -115,7 +115,7 @@ Applies to every GKI `workflow_dispatch` workflow ([`kernel-custom.yml`](.github
 
 On GitHub Actions and the app GKI build screen, **Latest(最新)** sits between **Dev** and **Custom**. [`resolve-ksu-ref.sh`](.github/scripts/resolve-ksu-ref.sh) resolves upstream KernelSU sources at run time:
 
-- **Official / SukiSU / ReSukiSU (GKI):** kernel and manager share the `head_sha` of the latest successful upstream `build-manager` run on `main` (not raw branch HEAD). Manager APK via [nightly.link](https://nightly.link/) (`manager.zip` or `Manager-release.zip`). If there is no green `build-manager` on `main`, Latest resolution fails early.
+- **Official / SukiSU / ReSukiSU (GKI):** prefer upstream `main` **HEAD** when that commit has a successful `release.yml` (tag release) or standalone `build-manager.yml` run; kernel and manager share that `head_sha`. Otherwise fall back to the latest successful standalone `build-manager` on `main`. Manager APK via [nightly.link](https://nightly.link/) (`manager.zip` or `Manager-release.zip`); download also checks `release.yml` runs. Latest fails if neither path has a usable green run on `main`.
 
 If manager download fails, the manager job step fails but **the kernel build continues**. Latest does not fall back to `releases/latest` (the Stable/Dev release path).
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sukisu=
 
 在 GitHub Actions 与 App 的 GKI 构建界面中，**Latest(最新)** 位于 **Dev** 与 **Custom** 之间，由 [`resolve-ksu-ref.sh`](.github/scripts/resolve-ksu-ref.sh) 在运行时解析上游 KernelSU 来源：
 
-- **Official / SukiSU / ReSukiSU（GKI）：** 内核与管理器共用上游 `main` 上最近一次成功的 `build-manager` 的 `head_sha`（非分支 HEAD）。管理器经 [nightly.link](https://nightly.link/) 拉取（`manager.zip` 或 `Manager-release.zip`）。若 `main` 上无成功的 `build-manager`，Latest 解析阶段直接失败。
+- **Official / SukiSU / ReSukiSU（GKI）：** 优先使用上游 `main` 的 **HEAD**，当该提交存在成功的 `release.yml`（标签发布）或独立的 `build-manager.yml` 时，内核与管理器共用该 `head_sha`；否则回退到 `main` 上最近一次成功的独立 `build-manager`。管理器经 [nightly.link](https://nightly.link/) 拉取（`manager.zip` 或 `Manager-release.zip`）；下载时同样会查找 `release.yml` 的 run。若 `main` 上两者皆无可用 CI，Latest 解析失败。
 
 若管理器下载失败，管理器 job 对应步骤会失败，但**内核构建仍会继续**。Latest 不会回退到 `releases/latest`（Stable/Dev 用的发布包路径）。
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -170,7 +170,7 @@
     <string name="build_ksu_branch">KSU branch</string>
     <string name="build_custom_ksu_ref">Custom KSU commit/ref</string>
     <string name="build_custom_ksu_ref_placeholder">e.g. abc123, branch:5, or tag</string>
-    <string name="build_ksu_branch_latest_hint">Builds the kernel from the commit of the latest successful upstream build-manager run on main. The manager APK is fetched via nightly.link from that same run. If the manager download fails, the kernel build still continues.</string>
+    <string name="build_ksu_branch_latest_hint">Prefers upstream main HEAD when that commit has a successful Release or build-manager CI run; otherwise falls back to the latest successful standalone build-manager on main. The manager APK is fetched via nightly.link from that run. If the manager download fails, the kernel build still continues.</string>
     <string name="build_no_root_scheme_desc">Do not inject any root authorization scheme. KSU branch, SUSFS, and KPM will be disabled automatically.</string>
     <string name="build_oneplus_no_root_scheme_desc">Build a rootless OnePlus kernel. SUSFS and KPM will be disabled automatically.</string>
     <string name="build_oneplus_ksu_branch_desc">OnePlus builds use the upstream default branch for the selected KernelSU variant.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -143,7 +143,7 @@
     <string name="build_ksu_branch">Ветка KSU</string>
     <string name="build_custom_ksu_ref">Свой KSU commit/ref</string>
     <string name="build_custom_ksu_ref_placeholder">например, abc123, branch:5 или tag</string>
-    <string name="build_ksu_branch_latest_hint">Ядро и менеджер с одного коммита — последнего успешного build-manager на upstream main. APK менеджера через nightly.link с того же run. Если менеджер не скачается, сборка ядра продолжится.</string>
+    <string name="build_ksu_branch_latest_hint">Сначала HEAD upstream main, если на этом коммите есть успешный Release или build-manager CI; иначе — последний успешный standalone build-manager на main. APK менеджера через nightly.link с того же run. Если менеджер не скачается, сборка ядра продолжится.</string>
     <string name="build_no_root_scheme_desc">Не внедрять схему авторизации root. Ветка KSU, SUSFS и KPM будут автоматически отключены.</string>
     <string name="build_ksu_none">None (без root)</string>
     <string name="build_standard">стабильная</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="build_ksu_branch">KSU 分支</string>
     <string name="build_custom_ksu_ref">自定义 KSU commit/ref</string>
     <string name="build_custom_ksu_ref_placeholder">例如: abc123, branch:5, 或 tag</string>
-    <string name="build_ksu_branch_latest_hint">内核与管理器使用上游 main 上最近一次成功的 build-manager 的同一提交；管理器 APK 经 nightly.link 拉取。若管理器下载失败，内核构建仍会继续。</string>
+    <string name="build_ksu_branch_latest_hint">优先使用 upstream main 的 HEAD（该提交有成功的 Release 或 build-manager CI 时）；否则回退到 main 上最近一次成功的 build-manager。管理器 APK 经 nightly.link 从对应 run 拉取。若管理器下载失败，内核构建仍会继续。</string>
     <string name="build_no_root_scheme_desc">不注入任何 Root 授权方案；KSU 分支、SUSFS 和 KPM 会自动关闭。</string>
     <string name="build_oneplus_no_root_scheme_desc">构建无 Root 的 OnePlus 内核；SUSFS 和 KPM 会自动关闭。</string>
     <string name="build_oneplus_ksu_branch_desc">OnePlus 构建使用对应 KernelSU 上游默认分支。</string>

--- a/app_dev/strings.xml
+++ b/app_dev/strings.xml
@@ -155,7 +155,7 @@
     <string name="build_ksu_branch">KSU 分支</string>
     <string name="build_custom_ksu_ref">自定义 KSU commit/ref</string>
     <string name="build_custom_ksu_ref_placeholder">例如: abc123, branch:5, 或 tag</string>
-    <string name="build_ksu_branch_latest_hint">内核与管理器使用上游 main 上最近一次成功的 build-manager 的同一提交；管理器 APK 经 nightly.link 拉取。若管理器下载失败，内核构建仍会继续。</string>
+    <string name="build_ksu_branch_latest_hint">优先使用 upstream main 的 HEAD（该提交有成功的 Release 或 build-manager CI 时）；否则回退到 main 上最近一次成功的 build-manager。管理器 APK 经 nightly.link 从对应 run 拉取。若管理器下载失败，内核构建仍会继续。</string>
     <string name="build_no_root_scheme_desc">不注入任何 Root 授权方案；KSU 分支、SUSFS 和 KPM 会自动关闭。</string>
     <string name="build_oneplus_no_root_scheme_desc">构建无 Root 的 OnePlus 内核；SUSFS 和 KPM 会自动关闭。</string>
     <string name="build_oneplus_ksu_branch_desc">OnePlus 构建使用对应 KernelSU 上游默认分支。</string>


### PR DESCRIPTION
### Summary
For KSU branch **`Latest(最新)`**, kernel ref and manager APK now resolve from the same **`main` HEAD** commit when either **`release.yml`** or **`build-manager.yml`** succeeded at that SHA. Manager download uses the same lookup order for the resolved commit.
### Details
**`Latest` resolution**
1. `main` HEAD  
2. `release.yml` @ HEAD, else `build-manager.yml` @ HEAD  
3. else last successful `build-manager` on `main`
**Manager artifacts** (for the resolved SHA): `build-manager` → `release` → fallback `main`.
Shared helpers live in `resolve-ksu-ref.sh` (safe to `source` from `download-manager-from-actions.sh`). README / `build_ksu_branch_latest_hint` strings mention Release or build-manager on `main` HEAD.
`Stable`, pinned refs, and custom `branch:N` are unchanged.