### PR TITLE
[3] fix(app): harden JNI copies and module WebUI paths

### DIFF
--- a/app/src/main/cpp/abk_ksu_jni.cc
+++ b/app/src/main/cpp/abk_ksu_jni.cc
@@ -7,6 +7,7 @@
 #include <sys/wait.h>
 
 #include <android/log.h>
+#include <cstdio>
 #include <cstring>
 #include <string>
 
@@ -131,6 +132,18 @@ static void fillArrayWithList(JNIEnv *env, jobject list, int *data, int count) {
     }
 }
 
+/** Copy JNI UTF-8 into a fixed buffer; rejects overflow (strlen >= bufSize). */
+static bool copyUtf8ToBuffer(char *buf, size_t bufSize, const char *utf) {
+    if (!buf || bufSize == 0 || !utf) {
+        return false;
+    }
+    if (strlen(utf) >= bufSize) {
+        return false;
+    }
+    snprintf(buf, bufSize, "%s", utf);
+    return true;
+}
+
 extern "C"
 JNIEXPORT jobject JNICALL
 Java_com_abk_kernel_utils_AbkKsuNative_getAppProfile(JNIEnv *env, jobject, jstring pkg, jint uid) {
@@ -140,13 +153,20 @@ Java_com_abk_kernel_utils_AbkKsuNative_getAppProfile(JNIEnv *env, jobject, jstri
 
     p_key_t key = {};
     auto cpkg = env->GetStringUTFChars(pkg, nullptr);
-    strcpy(key, cpkg);
+    if (!cpkg || !copyUtf8ToBuffer(key, sizeof(key), cpkg)) {
+        if (cpkg) {
+            env->ReleaseStringUTFChars(pkg, cpkg);
+        }
+        return nullptr;
+    }
     env->ReleaseStringUTFChars(pkg, cpkg);
 
     app_profile profile = {};
     profile.version = KSU_APP_PROFILE_VER;
 
-    strcpy(profile.key, key);
+    if (!copyUtf8ToBuffer(profile.key, sizeof(profile.key), key)) {
+        return nullptr;
+    }
     profile.curr_uid = uid;
 
     bool useDefaultProfile = get_app_profile(&profile) != 0;
@@ -259,7 +279,12 @@ Java_com_abk_kernel_utils_AbkKsuNative_setAppProfile(JNIEnv *env, jobject clazz,
 
     auto cpkg = env->GetStringUTFChars((jstring) key, nullptr);
     p_key_t p_key = {};
-    strcpy(p_key, cpkg);
+    if (!cpkg || !copyUtf8ToBuffer(p_key, sizeof(p_key), cpkg)) {
+        if (cpkg) {
+            env->ReleaseStringUTFChars((jstring) key, cpkg);
+        }
+        return false;
+    }
     env->ReleaseStringUTFChars((jstring) key, cpkg);
 
     auto currentUid = env->GetIntField(profile, currentUidField);
@@ -275,7 +300,9 @@ Java_com_abk_kernel_utils_AbkKsuNative_setAppProfile(JNIEnv *env, jobject clazz,
     app_profile p = {};
     p.version = KSU_APP_PROFILE_VER;
 
-    strcpy(p.key, p_key);
+    if (!copyUtf8ToBuffer(p.key, sizeof(p.key), p_key)) {
+        return false;
+    }
     p.allow_su = allowSu;
     p.curr_uid = currentUid;
 
@@ -283,8 +310,18 @@ Java_com_abk_kernel_utils_AbkKsuNative_setAppProfile(JNIEnv *env, jobject clazz,
         p.rp_config.use_default = env->GetBooleanField(profile, rootUseDefaultField);
         auto templateName = env->GetObjectField(profile, rootTemplateField);
         if (templateName) {
+            if (env->GetStringLength((jstring) templateName) > KSU_MAX_PACKAGE_NAME) {
+                return false;
+            }
             auto ctemplateName = env->GetStringUTFChars((jstring) templateName, nullptr);
-            strcpy(p.rp_config.template_name, ctemplateName);
+            if (!ctemplateName ||
+                !copyUtf8ToBuffer(p.rp_config.template_name,
+                        sizeof(p.rp_config.template_name), ctemplateName)) {
+                if (ctemplateName) {
+                    env->ReleaseStringUTFChars((jstring) templateName, ctemplateName);
+                }
+                return false;
+            }
             env->ReleaseStringUTFChars((jstring) templateName, ctemplateName);
         }
 
@@ -301,9 +338,21 @@ Java_com_abk_kernel_utils_AbkKsuNative_setAppProfile(JNIEnv *env, jobject clazz,
 
         p.rp_config.profile.capabilities.effective = capListToBits(env, capabilities);
 
-        auto cdomain = env->GetStringUTFChars((jstring) domain, nullptr);
-        strcpy(p.rp_config.profile.selinux_domain, cdomain);
-        env->ReleaseStringUTFChars((jstring) domain, cdomain);
+        if (domain) {
+            if (env->GetStringLength((jstring) domain) > KSU_SELINUX_DOMAIN) {
+                return false;
+            }
+            auto cdomain = env->GetStringUTFChars((jstring) domain, nullptr);
+            if (!cdomain ||
+                !copyUtf8ToBuffer(p.rp_config.profile.selinux_domain,
+                        sizeof(p.rp_config.profile.selinux_domain), cdomain)) {
+                if (cdomain) {
+                    env->ReleaseStringUTFChars((jstring) domain, cdomain);
+                }
+                return false;
+            }
+            env->ReleaseStringUTFChars((jstring) domain, cdomain);
+        }
 
         p.rp_config.profile.namespaces = env->GetIntField(profile, namespacesField);
     } else {

--- a/app/src/main/java/com/abk/kernel/ui/webui/ModuleWebUiActivity.kt
+++ b/app/src/main/java/com/abk/kernel/ui/webui/ModuleWebUiActivity.kt
@@ -2,6 +2,7 @@ package com.abk.kernel.ui.webui
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Context
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
@@ -19,6 +20,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.abk.kernel.R
 import com.abk.kernel.data.repository.PreferencesRepository
+import com.abk.kernel.utils.LocaleHelper
 import com.abk.kernel.utils.RootUtils
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -30,6 +32,10 @@ import kotlin.concurrent.thread
 class ModuleWebUiActivity : Activity() {
 
     private lateinit var webView: WebView
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleHelper.applyLocale(newBase))
+    }
     private val moduleId: String by lazy {
         intent.getStringExtra(EXTRA_MODULE_ID).orEmpty().trim()
     }
@@ -43,7 +49,7 @@ class ModuleWebUiActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (moduleId.isBlank()) {
+        if (!RootUtils.isSafeModuleIdForPath(moduleId)) {
             Toast.makeText(this, getString(R.string.runtime_module_unavailable), Toast.LENGTH_SHORT).show()
             finish()
             return
@@ -51,10 +57,21 @@ class ModuleWebUiActivity : Activity() {
 
         enterImmersiveMode()
         title = moduleName
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        thread(name = "abk-webui-init") {
             val debugEnabled = runCatching {
-                runBlocking { PreferencesRepository(this@ModuleWebUiActivity).webViewDebugEnabled.first() }
+                runBlocking {
+                    PreferencesRepository(applicationContext).webViewDebugEnabled.first()
+                }
             }.getOrDefault(false)
+            runOnUiThread {
+                if (isFinishing) return@runOnUiThread
+                setupWebView(debugEnabled)
+            }
+        }
+    }
+
+    private fun setupWebView(debugEnabled: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             WebView.setWebContentsDebuggingEnabled(debugEnabled)
         }
         webView = WebView(this).apply {

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -42,6 +42,8 @@ object RootUtils {
     private const val BUNDLED_KSUD_METADATA_NAME = "source.properties"
     private const val BUNDLED_KSUD_INSTALL_DIR = "bundled-ksud"
     private const val ABK_META_MOUNT_ID = "meta-abk-mount"
+    /** Matches KernelSU/Magisk folder names under /data/adb/modules (see meta-abk-mount). */
+    private val SAFE_MODULE_ID_FOR_PATH = Regex("^[A-Za-z0-9._-]+$")
     private const val ABK_META_MOUNT_DIR = "/data/adb/modules/meta-abk-mount"
     private const val ABK_META_MOUNT_WEB_ROOT = "/data/adb/modules/meta-abk-mount/webroot"
     private const val ABK_META_MOUNT_SYSFS_ENABLED = "/sys/kernel/abk_meta_mount/enabled"
@@ -75,7 +77,7 @@ object RootUtils {
     }
 
     fun init(context: Context) {
-        appContext = context.applicationContext
+        appContext = context.applicationContext ?: context
         Shell.enableVerboseLogging = false
         Shell.setDefaultBuilder(
             Shell.Builder.create()
@@ -914,10 +916,21 @@ object RootUtils {
         return execRootScript(prefix + command, timeoutSeconds = timeoutSeconds)
     }
 
+    /**
+     * True when [moduleId] is safe to embed in /data/adb/modules/{id}/ paths (WebUI, module info).
+     */
+    fun isSafeModuleIdForPath(moduleId: String): Boolean =
+        sanitizeModuleIdForPath(moduleId) != null
+
+    private fun sanitizeModuleIdForPath(moduleId: String): String? {
+        val clean = moduleId.trim()
+        if (clean.isEmpty() || !SAFE_MODULE_ID_FOR_PATH.matches(clean)) return null
+        return clean
+    }
+
     fun readModuleWebResource(moduleId: String, relativePath: String): ByteArray? {
-        val cleanId = moduleId.trim()
+        val cleanId = sanitizeModuleIdForPath(moduleId) ?: return null
         val cleanRelativePath = sanitizeWebRelativePath(relativePath) ?: return null
-        if (cleanId.isBlank()) return null
 
         if (isAbkMetaMountModuleId(cleanId)) {
             ensureAbkMetaMountPlaceholder()
@@ -954,8 +967,7 @@ object RootUtils {
     }
 
     fun moduleInfoJson(moduleId: String): String {
-        val cleanId = moduleId.trim()
-        if (cleanId.isBlank()) return "{}"
+        val cleanId = sanitizeModuleIdForPath(moduleId) ?: return "{}"
         val moduleDir = "/data/adb/modules/$cleanId"
         val webRoot = "$moduleDir/webroot"
         val modules = listKsuModules().takeIf { it.success }?.output?.joinToString("\n").orEmpty()
@@ -1546,7 +1558,7 @@ object RootUtils {
         val shell = builder.build()
         if (isShellRoot(shell)) return shell
         shell.close()
-        error("Root shell unavailable")
+        throw IllegalStateException("Root shell unavailable")
     }
 
     private fun isShellRoot(shell: Shell): Boolean {

--- a/app_dev/build.gradle.kts
+++ b/app_dev/build.gradle.kts
@@ -39,6 +39,7 @@ android {
         buildConfigField("String", "GITHUB_CLIENT_ID", "\"${githubClientId.get()}\"")
         buildConfigField("String", "SOURCE_REPO_OWNER", "\"xingguangcuican6666\"")
         buildConfigField("String", "SOURCE_REPO_NAME", "\"ABK\"")
+        buildConfigField("String", "SOURCE_REPO_DEFAULT_BRANCH", "\"dev\"")
         buildConfigField("String", "UPSTREAM_REPO_URL", "\"https://github.com/zzh20188/GKI_KernelSU_SUSFS\"")
         buildConfigField("String", "TOP_LEVEL_REPO_URL", "\"https://github.com/WildKernels/GKI_KernelSU_SUSFS\"")
 

--- a/app_dev/strings.xml
+++ b/app_dev/strings.xml
@@ -91,9 +91,24 @@
     <string name="sync_action">立即同步</string>
     <string name="sync_behind_commits">落后 %1$d 个提交。</string>
     <string name="skip">跳过</string>
+    <string name="oobe_title">开始使用 AnyBase Kernel</string>
+    <string name="oobe_desc">首次启动只展示一次。你可以先跳过，之后需要构建时再登录 GitHub。</string>
+    <string name="oobe_first_launch">首次启动</string>
+    <string name="oobe_build_title">构建功能需要 GitHub</string>
+    <string name="oobe_build_desc">登录后 ABK 才能检查 fork、触发工作流并同步构建状态。</string>
+    <string name="oobe_build_detail">如果暂时不构建内核，可以先跳过。切到构建页时再继续登录和 fork 流程。</string>
+    <string name="oobe_flash_title">刷写页可直接浏览预编译 GKI</string>
+    <string name="oobe_flash_desc">未登录时，刷写页只保留 Release 里的预编译 GKI 下载。</string>
+    <string name="oobe_flash_detail">工作流构建产物、fork 仓库和 Actions 记录会在登录并完成 fork 检查后恢复可用。</string>
+    <string name="oobe_continue_setup">继续配置 GitHub</string>
+    <string name="oobe_skip_for_now">暂时跳过</string>
 
     <!-- Build -->
     <string name="build_title">构建内核</string>
+    <string name="build_login_required_title">登录 GitHub 后才能构建</string>
+    <string name="build_login_required_desc">ABK 现在不会在启动时强制登录。需要构建内核时，再进入 OOBE 完成 GitHub 授权即可。</string>
+    <string name="build_fork_required_title">还需要完成 fork 配置</string>
+    <string name="build_fork_required_desc">当前账号已登录，但还没有可用的 fork 仓库。继续 OOBE 后，ABK 会检查并引导完成 fork。</string>
     <string name="build_target_title">构建目标</string>
     <string name="build_target_desc">选择标准 GKI 构建或 OnePlus/Oplus 机型构建。</string>
     <string name="build_target_gki">GKI</string>
@@ -330,6 +345,8 @@
     <string name="flash_loading_release">正在获取 Release</string>
     <string name="flash_empty_prebuilt_title">暂无预编译 GKI Release</string>
     <string name="flash_empty_prebuilt_desc">本仓库 Release 中暂未发现可浏览的版本。</string>
+    <string name="flash_prebuilt_disabled_title">预编译 GKI 已关闭</string>
+    <string name="flash_prebuilt_disabled_desc">未登录状态下，刷写页只保留预编译 GKI 下载。可在设置里重新开启该功能。</string>
     <string name="flash_workflow_unavailable">工作流记录不可用</string>
     <string name="flash_workflow_unavailable_desc">该工作流产物已被刷新或删除。</string>
     <string name="flash_loading_prebuilt">正在获取 %1$s 的预编译 GKI</string>
@@ -743,6 +760,7 @@
     <string name="module_repo_back">返回模块仓库</string>
     <string name="module_repo_no_matching">没有匹配的模块</string>
     <string name="module_repo_no_central">还没有中央仓库</string>
+    <string name="module_repo_building_list">正在构建模块列表</string>
     <string name="module_repo_refresh_hint">刷新中央仓库后会显示模块</string>
     <string name="module_repo_no_display">没有可显示的模块</string>
     <string name="module_repo_manage_central">管理中央仓库</string>
@@ -875,6 +893,7 @@
     <string name="vm_runtime_module_uninstall_unsupported">当前模块不支持卸载</string>
     <string name="vm_runtime_module_default_name">模块</string>
     <string name="vm_auth_failed">授权失败: %1$s</string>
+    <string name="vm_build_login_required">请先完成 GitHub 登录和 fork 配置，再提交构建。</string>
     <string name="vm_workflow_still_disabled">工作流仍未启用，当前状态: %1$s</string>
     <string name="vm_workflow_dispatch_failed">触发工作流失败: %1$s</string>
     <string name="vm_build_dispatch_no_result">触发构建未返回结果</string>


### PR DESCRIPTION
## Independence from #80 / #81

This is only **“PR 3” in my split numbering** — not a hard third step in the merge queue.

**These changes do not depend on:**

- [#80](https://github.com/xingguangcuican6666/ABK/pull/80) — VM / coordinators refactor  
- [#81](https://github.com/xingguangcuican6666/ABK/pull/81) — Flash / UI polish  

No Flash, coordinators refactor, or snackbar / workflow-i18n work here. The functional diff is **JNI hardening + module WebUI path safety** on top of current upstream `dev`.

**You can merge this PR on its own**, before, after, or in parallel with #80 / #81. I opened #80 / #81 first on my fork for review convenience, not because this code requires them. Local merge checks into `dev`, #80, and #81 branches were clean.

**Use branch `split/01-jni-webui-only` for this PR** — the compare should show a small diff on `dev`, not the old stacked branch. Do **not** use `split/01-jni-webui` → `dev`; that branch still carries #80 + #81.

---

## What is in this PR (2 commits)

| Commit | Purpose |
|--------|---------|
| `fix(app): harden JNI copies and module WebUI paths` | Product change (3 files) |
| `fix(app-dev): sync strings and BuildConfig for CI dev build` | Lets **Build ABK App Dev** pass (no behavior change in release `app/`) |

### Product files (hardening)

- `app/src/main/cpp/abk_ksu_jni.cc`
- `app/src/main/java/com/abk/kernel/utils/RootUtils.kt`
- `app/src/main/java/com/abk/kernel/ui/webui/ModuleWebUiActivity.kt`

### CI-only (dev workflow copies `app_dev` → `app/` before `assembleDebug`)

- `app_dev/strings.xml` — adds string keys already present in `app/src/main/res/values/strings.xml` on `dev` but missing from `app_dev` (OOBE, build gate, flash prebuilt, etc.)
- `app_dev/build.gradle.kts` — adds `SOURCE_REPO_DEFAULT_BRANCH` (already in `app/build.gradle.kts` on `dev`)

**Not in this PR:** `PreferencesRepository.kt` (no new APIs; avoids duplicating [#80](https://github.com/xingguangcuican6666/ABK/pull/80)). No cert / signing changes.

---

## Context

Small hardening slice: safer JNI string copies for KSU app profiles, validation of module IDs before `/data/adb/modules/…` paths for WebUI, and WebView debug flag read off the main thread.

---

## Native — `abk_ksu_jni.cc`

Replaced unchecked **`strcpy`** into fixed buffers with **`copyUtf8ToBuffer`** (`snprintf`, fails if `strlen(utf) >= bufSize`).

**Methods updated:**

- **`getAppProfile`** — package name → `key` / `profile.key`; returns `null` on bad input.
- **`setAppProfile`** — package `key`; root template name (length cap `KSU_MAX_PACKAGE_NAME`); SELinux domain only when non-null (cap `KSU_SELINUX_DOMAIN`). Early `false` / `null` on overflow.

Other JNI exports in this file are **unchanged** in this PR (e.g. command path still uses `GetStringUTFChars` as before).

---

## `RootUtils.kt` — module paths

- Regex **`SAFE_MODULE_ID_FOR_PATH`**: `^[A-Za-z0-9._-]+$` (normal KSU/Magisk module folder names).
- **`sanitizeModuleIdForPath`** / **`isSafeModuleIdForPath`** — public check for UI; internal sanitize before any `/data/adb/modules/{id}/` use.
- **`readModuleWebResource`**, **`moduleInfoJson`** — use sanitize instead of `trim()` + blank check only.

**Also in this file (minor):**

- **`init`:** `applicationContext ?: context`.
- Root shell unavailable: **`IllegalStateException`** instead of Kotlin `error()`.

---

## `ModuleWebUiActivity.kt` — module WebUI

- **`attachBaseContext`:** `LocaleHelper.applyLocale` (same locale as the rest of the app).
- **Open gate:** `RootUtils.isSafeModuleIdForPath(moduleId)` instead of `moduleId.isBlank()` — blocks unsafe IDs before WebView starts.
- **WebView setup:** a background thread reads **`webViewDebugEnabled`** via `runBlocking { … .first() }`, then **`setupWebView`** on the UI thread — no DataStore read on the main thread in `onCreate`. Uses existing `PreferencesRepository` API on plain `dev` (does **not** add `readWebViewDebugEnabledBlocking`; that helper lives in #80 if you merge it).

No change to WebView protocol or asset loading beyond the module-id gate.

---

## What is **not** in this PR

- Flash tab, `ui/components/*`, screen polish — **#81**.
- ViewModel refactor, coordinators, build monitor, workflow step i18n — **#80**.
- New user-facing features — hardening and WebUI init only.

---

## Merge order (suggested, not required)

| PR | Relationship to this one |
|----|---------------------------|
| **#80** | Independent — can merge before or after |
| **#81** | Independent — can merge before or after |
| **#82 (this)** | Standalone on `dev` (JNI + app_dev CI sync) |
