### PR TITLE
add build submitted confirmation dialog

### DIFF
--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -618,7 +618,8 @@ private fun AbkMainScaffold(
                         AbkTab.Build -> BuildScreen(
                             vm = vm,
                             outerPadding = contentPadding,
-                            onPlanPageVisibleChange = { buildPlanPageVisible = it }
+                            onPlanPageVisibleChange = { buildPlanPageVisible = it },
+                            onNavigateToStatus = { selectedTab = AbkTab.Status }
                         )
                         AbkTab.Modules -> ModuleRepositoryScreen(
                             vm = vm,

--- a/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
@@ -103,7 +103,8 @@ private const val CATALOG_MODULE_REMOVE_DELAY_MS = 260L
 fun BuildScreen(
     vm: MainViewModel,
     outerPadding: PaddingValues = PaddingValues(0.dp),
-    onPlanPageVisibleChange: (Boolean) -> Unit = {}
+    onPlanPageVisibleChange: (Boolean) -> Unit = {},
+    onNavigateToStatus: () -> Unit = {}
 ) {
     val state by vm.uiState.collectAsState()
     val context = LocalContext.current
@@ -139,6 +140,7 @@ fun BuildScreen(
         buildTimePreview(context, config.buildTime)
     }
     var showConfirmDialog by remember { mutableStateOf(false) }
+    var showBuildSubmittedDialog by rememberSaveable { mutableStateOf(false) }
     var showSavePlanDialog by remember { mutableStateOf(false) }
     var showImportPlanDialog by remember { mutableStateOf(false) }
     var showPlanLibraryPage by rememberSaveable { mutableStateOf(false) }
@@ -269,6 +271,34 @@ fun BuildScreen(
         }
     }
 
+
+    if (showBuildSubmittedDialog) {
+        AlertDialog(
+            onDismissRequest = {},
+            icon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+            title = {
+                Text(
+                    text = stringResource(R.string.build_submitted_title),
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = { Text(stringResource(R.string.build_submitted_desc)) },
+            confirmButton = {
+                FilledTonalButton(onClick = {
+                    showBuildSubmittedDialog = false
+                    onNavigateToStatus()
+                }) {
+                    Text(stringResource(R.string.build_submitted_ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showBuildSubmittedDialog = false }) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        )
+    }
+
     if (showConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showConfirmDialog = false },
@@ -365,6 +395,7 @@ fun BuildScreen(
                 Button(onClick = {
                     showConfirmDialog = false
                     vm.dispatchBuild(config)
+                    showBuildSubmittedDialog = true
                 }) { Text(stringResource(R.string.confirm)) }
             },
             dismissButton = {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -120,6 +120,9 @@
     <string name="build_failed">Build failed</string>
     <string name="build_queued">Build queued</string>
     <string name="build_confirm_submit">Confirm build submission</string>
+    <string name="build_submitted_title">Build submitted</string>
+    <string name="build_submitted_desc">Build submitted successfully. Go to Status to track progress.</string>
+    <string name="build_submitted_ok">OK</string>
     <string name="build_config_overview">Build configuration overview:</string>
     <string name="build_kernel_line">Android %1$s · Kernel %2$s.%3$s</string>
     <string name="build_patch_level_line">Patch level: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -120,6 +120,9 @@
     <string name="build_failed">Сборка не удалась</string>
     <string name="build_queued">Сборка в очереди</string>
     <string name="build_confirm_submit">Подтвердить сборку</string>
+    <string name="build_submitted_title">Сборка отправлена</string>
+    <string name="build_submitted_desc">Сборка успешно отправлена. Перейдите в «Текущий статус», чтобы отслеживать прогресс.</string>
+    <string name="build_submitted_ok">ОК</string>
     <string name="build_config_overview">Сводка конфигурации сборки:</string>
     <string name="build_kernel_line">Android %1$s · ядро %2$s.%3$s</string>
     <string name="build_patch_level_line">Уровень патча: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,9 @@
     <string name="build_failed">构建失败</string>
     <string name="build_queued">构建已排队</string>
     <string name="build_confirm_submit">确认提交构建</string>
+    <string name="build_submitted_title">构建已提交</string>
+    <string name="build_submitted_desc">构建已成功提交，可前往「当前状态」页查看进度。</string>
+    <string name="build_submitted_ok">确定</string>
     <string name="build_config_overview">构建配置概览：</string>
     <string name="build_kernel_line">Android %1$s · 内核 %2$s.%3$s</string>
     <string name="build_patch_level_line">补丁级别: %1$s</string>


### PR DESCRIPTION
After confirming the build submission dialog, a "Build submitted" reminder dialog appears
   Tap "OK" to navigate to the "Status" page to check build progress
   Tap "Close" to stay on the current page