### PR TITLE
fix(ci): create PR for version metadata updates

### DIFF
--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -562,7 +562,7 @@ jobs:
           git restore --staged --worktree version.json app/build.gradle.kts app/src/main/res/values/strings.xml 2>/dev/null || true
 
           python .github/scripts/update-version-json.py \
-            --channel normal \
+            --channel dev \
             --workflow-name "${GITHUB_WORKFLOW}" \
             --run-id "${GITHUB_RUN_ID}" \
             --commit-sha "${GITHUB_SHA}" \
@@ -584,6 +584,10 @@ jobs:
           title: "chore(app): update unstable version metadata"
           body: |
             Automated update of unstable version metadata.
+
+            Changes:
+            - Updated version metadata
+            - Updated build information
 
             Workflow: ${{ github.workflow }}
             Run ID: ${{ github.run_id }}

--- a/.github/workflows/build-abk-app-dev.yml
+++ b/.github/workflows/build-abk-app-dev.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pull-requests: write
     env:
       HAS_RELEASE_SIGNING: ${{ secrets.ABK_RELEASE_KEYSTORE_BASE64 != '' && secrets.ABK_RELEASE_STORE_PASSWORD != '' && secrets.ABK_RELEASE_KEY_ALIAS != '' && secrets.ABK_RELEASE_KEY_PASSWORD != '' }}
       SUKISU_ULTRA_REPO: https://github.com/SukiSU-Ultra/SukiSU-Ultra.git
@@ -552,39 +553,50 @@ jobs:
           fi
           "$ANDROID_HOME/build-tools/37.0.0/apksigner" verify --verbose "$signed_apk"
 
-      - name: Commit version.json
+      - name: Prepare version metadata
         if: ${{ github.repository == 'xingguangcuican6666/ABK' && github.event_name != 'pull_request' && startsWith(github.ref, 'refs/heads/') }}
+        id: version
         run: |
           set -euo pipefail
-          branch="${GITHUB_REF_NAME}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          for attempt in 1 2 3 4 5; do
-            git restore --staged --worktree version.json app/build.gradle.kts app/src/main/res/values/strings.xml 2>/dev/null || true
-            git fetch origin "${branch}"
-            git checkout "${branch}"
-            git pull --rebase origin "${branch}"
-            python .github/scripts/update-version-json.py \
-              --channel dev \
-              --workflow-name "${GITHUB_WORKFLOW}" \
-              --run-id "${GITHUB_RUN_ID}" \
-              --commit-sha "${GITHUB_SHA}" \
-              --published-at "${ABK_APP_BUILD_TIMESTAMP}" \
-              --build-timestamp-epoch-millis "${ABK_APP_BUILD_TIMESTAMP_EPOCH_MILLIS}"
-            if git diff --quiet -- version.json; then
-              echo "version.json unchanged"
-              exit 0
-            fi
-            git add version.json
-            git commit -m "chore(app): update unstable version metadata"
-            if git push origin HEAD:${branch}; then
-              exit 0
-            fi
-            git reset --hard "origin/${branch}"
-            sleep $((attempt * 3))
-          done
-          echo "::error::Failed to push version.json after retries."
-          exit 1
+
+          git restore --staged --worktree version.json app/build.gradle.kts app/src/main/res/values/strings.xml 2>/dev/null || true
+
+          python .github/scripts/update-version-json.py \
+            --channel normal \
+            --workflow-name "${GITHUB_WORKFLOW}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --commit-sha "${GITHUB_SHA}" \
+            --published-at "${ABK_APP_BUILD_TIMESTAMP}" \
+            --build-timestamp-epoch-millis "${ABK_APP_BUILD_TIMESTAMP_EPOCH_MILLIS}"
+
+          if git diff --quiet -- version.json app/build.gradle.kts app/src/main/res/values/strings.xml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create version update PR
+        if: ${{ steps.version.outputs.changed == 'true' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(app): update unstable version metadata"
+          title: "chore(app): update unstable version metadata"
+          body: |
+            Automated update of unstable version metadata.
+
+            Workflow: ${{ github.workflow }}
+            Run ID: ${{ github.run_id }}
+            Commit: ${{ github.sha }}
+
+          branch: bot/update-version-json
+          base: ${{ github.ref_name }}
+          delete-branch: true
+
+          add-paths: |
+            version.json
+            app/build.gradle.kts
+            app/src/main/res/values/strings.xml
 
       - name: Upload APKs
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -581,6 +581,10 @@ jobs:
           body: |
             Automated update of unstable version metadata.
 
+            Changes:
+            - Updated version metadata
+            - Updated build information
+
             Workflow: ${{ github.workflow }}
             Run ID: ${{ github.run_id }}
             Commit: ${{ github.sha }}

--- a/.github/workflows/build-abk-app.yml
+++ b/.github/workflows/build-abk-app.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pull-requests: write
     env:
       HAS_RELEASE_SIGNING: ${{ secrets.ABK_RELEASE_KEYSTORE_BASE64 != '' && secrets.ABK_RELEASE_STORE_PASSWORD != '' && secrets.ABK_RELEASE_KEY_ALIAS != '' && secrets.ABK_RELEASE_KEY_PASSWORD != '' }}
       SUKISU_ULTRA_REPO: https://github.com/SukiSU-Ultra/SukiSU-Ultra.git
@@ -548,39 +549,50 @@ jobs:
           fi
           "$ANDROID_HOME/build-tools/37.0.0/apksigner" verify --verbose "$signed_apk"
 
-      - name: Commit version.json
+      - name: Prepare version metadata
         if: ${{ github.repository == 'xingguangcuican6666/ABK' && github.event_name != 'pull_request' && startsWith(github.ref, 'refs/heads/') }}
+        id: version
         run: |
           set -euo pipefail
-          branch="${GITHUB_REF_NAME}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          for attempt in 1 2 3 4 5; do
-            git restore --staged --worktree version.json app/build.gradle.kts app/src/main/res/values/strings.xml 2>/dev/null || true
-            git fetch origin "${branch}"
-            git checkout "${branch}"
-            git pull --rebase origin "${branch}"
-            python .github/scripts/update-version-json.py \
-              --channel normal \
-              --workflow-name "${GITHUB_WORKFLOW}" \
-              --run-id "${GITHUB_RUN_ID}" \
-              --commit-sha "${GITHUB_SHA}" \
-              --published-at "${ABK_APP_BUILD_TIMESTAMP}" \
-              --build-timestamp-epoch-millis "${ABK_APP_BUILD_TIMESTAMP_EPOCH_MILLIS}"
-            if git diff --quiet -- version.json; then
-              echo "version.json unchanged"
-              exit 0
-            fi
-            git add version.json
-            git commit -m "chore(app): update unstable version metadata"
-            if git push origin HEAD:${branch}; then
-              exit 0
-            fi
-            git reset --hard "origin/${branch}"
-            sleep $((attempt * 3))
-          done
-          echo "::error::Failed to push version.json after retries."
-          exit 1
+
+          git restore --staged --worktree version.json app/build.gradle.kts app/src/main/res/values/strings.xml 2>/dev/null || true
+
+          python .github/scripts/update-version-json.py \
+            --channel normal \
+            --workflow-name "${GITHUB_WORKFLOW}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --commit-sha "${GITHUB_SHA}" \
+            --published-at "${ABK_APP_BUILD_TIMESTAMP}" \
+            --build-timestamp-epoch-millis "${ABK_APP_BUILD_TIMESTAMP_EPOCH_MILLIS}"
+
+          if git diff --quiet -- version.json app/build.gradle.kts app/src/main/res/values/strings.xml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create version update PR
+        if: ${{ steps.version.outputs.changed == 'true' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(app): update unstable version metadata"
+          title: "chore(app): update unstable version metadata"
+          body: |
+            Automated update of unstable version metadata.
+
+            Workflow: ${{ github.workflow }}
+            Run ID: ${{ github.run_id }}
+            Commit: ${{ github.sha }}
+
+          branch: bot/update-version-json
+          base: ${{ github.ref_name }}
+          delete-branch: true
+
+          add-paths: |
+            version.json
+            app/build.gradle.kts
+            app/src/main/res/values/strings.xml
 
       - name: Upload APKs
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

Fixes #150

Replace the direct push workflow for version metadata updates with an automated Pull Request flow.

The previous workflow committed and pushed `version.json` directly to the target branch, which violated repository rules requiring changes to go through Pull Requests.

Changes:
- Replace direct `git push` with `peter-evans/create-pull-request`
- Keep automatic generation of version metadata
- Preserve updates for:
  - `version.json`
  - `app/build.gradle.kts`
  - `app/src/main/res/values/strings.xml`
- Respect branch protection and repository rules

## Testing

- Workflow syntax checked
- Verified the updated workflow keeps APK artifact upload unchanged