### PR TITLE
ci(codeql): use manual Android build for java-kotlin analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           - language: actions
             build-mode: none
           - language: c-cpp
-            build-mode: none
+            build-mode: manual
           - language: javascript-typescript
             build-mode: none
           - language: python
@@ -48,31 +48,40 @@ jobs:
           dependency-caching: true
 
       - name: Set up JDK
-        if: ${{ matrix.language == 'java-kotlin' }}
+        if: ${{ matrix.language == 'java-kotlin' || matrix.language == 'c-cpp' }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Android SDK
-        if: ${{ matrix.language == 'java-kotlin' }}
+        if: ${{ matrix.language == 'java-kotlin' || matrix.language == 'c-cpp' }}
         uses: android-actions/setup-android@v3
 
       - name: Install Android SDK packages
-        if: ${{ matrix.language == 'java-kotlin' }}
+        if: ${{ matrix.language == 'java-kotlin' || matrix.language == 'c-cpp' }}
         run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Set up Gradle
-        if: ${{ matrix.language == 'java-kotlin' }}
+        if: ${{ matrix.language == 'java-kotlin' || matrix.language == 'c-cpp' }}
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "9.3.1"
 
-      - name: Build Android app for CodeQL
+      - name: Build Java/Kotlin sources for CodeQL
         if: ${{ matrix.language == 'java-kotlin' }}
         run: >-
           gradle --no-daemon --no-build-cache --rerun-tasks
           :app:compileDebugKotlin :app:compileDebugJavaWithJavac
+
+      - name: Build native sources for CodeQL
+        if: ${{ matrix.language == 'c-cpp' }}
+        run: >-
+          gradle --no-daemon --no-build-cache --rerun-tasks
+          ':app:buildCMakeDebug[arm64-v8a]'
+          ':app:buildCMakeDebug[armeabi-v7a]'
+          ':app:buildCMakeDebug[x86]'
+          ':app:buildCMakeDebug[x86_64]'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,9 @@ jobs:
 
       - name: Build Android app for CodeQL
         if: ${{ matrix.language == 'java-kotlin' }}
-        run: gradle --no-daemon :app:assembleDebug
+        run: >-
+          gradle --no-daemon --no-build-cache --rerun-tasks
+          :app:compileDebugKotlin :app:compileDebugJavaWithJavac
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+  schedule:
+    - cron: "28 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix['build-mode'] }}
+          dependency-caching: true
+
+      - name: Set up JDK
+        if: ${{ matrix.language == 'java-kotlin' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Android SDK
+        if: ${{ matrix.language == 'java-kotlin' }}
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        if: ${{ matrix.language == 'java-kotlin' }}
+        run: sdkmanager --channel=3 "platforms;android-37.0" "build-tools;37.0.0" "cmake;3.22.1" "ndk;28.2.13676358"
+
+      - name: Set up Gradle
+        if: ${{ matrix.language == 'java-kotlin' }}
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.3.1"
+
+      - name: Build Android app for CodeQL
+        if: ${{ matrix.language == 'java-kotlin' }}
+        run: gradle --no-daemon :app:assembleDebug
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for this repository
- switch `java-kotlin` analysis to `build-mode: manual`
- reuse the Android SDK, CMake, NDK, and Gradle versions from the app CI workflow

## Why
The previous CodeQL default setup run on May 19, 2026 failed in `Analyze (java-kotlin)` because autobuild reached `:app:configureCMakeDebug[arm64-v8a]` without `CMake 3.22.1` installed.

## Notes
- this PR is intended to validate the workflow wiring on GitHub Actions
- repository CodeQL default setup is still configured as of July 17, 2026; after this workflow is verified, the repo should be switched to advanced setup so this workflow can own CodeQL uploads cleanly
