### PR TITLE
feat(app): 设置账户区域可直接进入 OOBE 登录

### DIFF
--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -727,7 +727,15 @@ private fun SettingsMainContent(
                 )
             } ?: ExpressiveListItem(
                 title = stringResource(R.string.settings_not_logged_in),
-                leadingIcon = Icons.Default.AccountCircle
+                subtitle = stringResource(R.string.settings_login_hint),
+                leadingIcon = Icons.Default.AccountCircle,
+                trailingContent = {
+                    Icon(
+                        Icons.Default.ChevronRight,
+                        contentDescription = stringResource(R.string.settings_login_hint)
+                    )
+                },
+                onClick = { vm.openLoginOobe() }
             )
         }
 

--- a/app/src/main/java/com/abk/kernel/viewmodel/AuthOobeCoordinator.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/AuthOobeCoordinator.kt
@@ -35,7 +35,12 @@ class AuthOobeCoordinator(
         }
     }
 
-    fun openBuildOobe() {
+    fun openBuildOobe() = enterOobeFlow()
+
+    /** Settings account entry: jump back into the OOBE flow so the user can sign in again. */
+    fun openLoginOobe() = enterOobeFlow()
+
+    private fun enterOobeFlow() {
         val state = readState()
         val nextStep = if (state.isLoggedIn && state.user != null) AuthStep.FORK_CHECK else AuthStep.LOGIN
         updateState {

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -870,6 +870,8 @@ class MainViewModel @JvmOverloads constructor(
 
     fun openBuildOobe() = authOobe.openBuildOobe()
 
+    fun openLoginOobe() = authOobe.openLoginOobe()
+
     fun continueOobeToLogin() = authOobe.continueOobeToLogin()
 
     fun skipOobe() = authOobe.skipOobe()

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -625,6 +625,7 @@
     <string name="settings_logout_desc">Sign out</string>
     <string name="settings_fork_repo">Fork repository</string>
     <string name="settings_not_logged_in">Not signed in</string>
+    <string name="settings_login_hint">Tap to sign in with GitHub</string>
     <string name="settings_auto_download_desc">Applies only to the next newly submitted build. Turning it off will not auto-download.</string>
     <string name="settings_prebuilt_gki">Prebuilt GKI fetch and download</string>
     <string name="settings_prebuilt_gki_desc">Fetch prebuilt GKI from this repository release. Downloads are manual.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -625,6 +625,7 @@
     <string name="settings_logout_desc">Выйти</string>
     <string name="settings_fork_repo">Fork-репозиторий</string>
     <string name="settings_not_logged_in">Не выполнен вход</string>
+    <string name="settings_login_hint">Нажмите, чтобы войти через GitHub</string>
     <string name="settings_auto_download_desc">Применяется только к следующей новой сборке. Если выключить, автозагрузки не будет.</string>
     <string name="settings_prebuilt_gki">Готовые сборки GKI</string>
     <string name="settings_prebuilt_gki_desc">Раздел готовых сборок GKI из Release репозитория. Скачивание вручную.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -654,6 +654,7 @@
     <string name="settings_logout_desc">退出登录</string>
     <string name="settings_fork_repo">Fork 仓库</string>
     <string name="settings_not_logged_in">未登录</string>
+    <string name="settings_login_hint">点击前往登录 GitHub 账户</string>
     <string name="settings_auto_download_desc">仅对下一次新提交的构建生效，关闭后不会自动下载</string>
     <string name="settings_prebuilt_gki">预编译 GKI 获取与下载</string>
     <string name="settings_prebuilt_gki_desc">从本仓库 Release 获取预编译 GKI，下载需手动触发</string>


### PR DESCRIPTION
## 背景

跳过 OOBE 进入主界面后，设置 → 账户区域只显示一行不可交互的「未登录」，没有任何重新登录的入口；从设置退出登录后也是同样的死路，只能清除应用数据才能再次登录。

## 改动

- **`SettingsScreen.kt`**：未登录时的账户行改为可点击项 —— 增加副标题「点击前往登录 GitHub 账户」与右侧 `ChevronRight` 箭头，点击整行调用 `vm.openLoginOobe()`，直接拉起 OOBE 登录页。
- **`AuthOobeCoordinator.kt`**：把 `openBuildOobe()` 的实现抽成私有的 `enterOobeFlow()`，新增语义明确的 `openLoginOobe()` 复用同一套逻辑。构建页原有入口行为不变。
- **`MainViewModel.kt`**：转发 `openLoginOobe()`。
- **strings**：新增 `settings_login_hint`（zh / en / ru 三种语言）。

## 行为说明

复用的入口逻辑已覆盖设置里显示「未登录」的两种状态：

| 状态 | 行为 |
|------|------|
| 无 token（`isLoggedIn = false`） | 直接进入 `AuthStep.LOGIN`，即 GitHub 设备码登录页 |
| 有 token 但用户信息拉取失败（`user == null`） | 先展示 LOGIN 页并后台重新拉取用户，成功后自动前进到 `FORK_CHECK` |

登录成功、fork 检查完成后 OOBE 覆盖层会自动关闭并回到原界面；过程中也可以用页面上的「暂时跳过」退出。`logout()` 不会重置 `oobeCompleted`，所以退出登录后不会误触发首次引导，账户行会回到这一可点击状态 —— 退出 → 重新登录的闭环现在是通的。

## 验证

- `gradle :app:compileDebugKotlin` 通过，无新增警告。
- 单元测试未能运行：`app/src/test/java/com/abk/kernel/data/repository/GitHubRepositoryNetworkTest.kt` 在本分支上**本来就编译不过**（`getRepo` 未解析等 3 个错误）。已通过 stash 掉本次改动复现同样的失败，与本 PR 无关。

## 备注

- 未改动 `app_dev/strings.xml`：dev 工作流只把 `app_dev/build.gradle.kts` 覆盖到 `app/`，该 strings 文件不参与构建，且已比主文件少 94 条。
- UI 变更截图待在真机上补充。
