### PR TITLE
fix(app): 修复设备码过期/被拒后登录按钮消失、无法重试的死路

### DIFF
--- a/app/src/main/java/com/abk/kernel/viewmodel/AuthOobeCoordinator.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/AuthOobeCoordinator.kt
@@ -47,6 +47,10 @@ class AuthOobeCoordinator(
             it.copy(
                 showOobe = true,
                 authStep = nextStep,
+                deviceCode = null,
+                userCode = null,
+                verificationUri = null,
+                isPollingToken = false,
                 error = null,
             )
         }
@@ -131,6 +135,9 @@ class AuthOobeCoordinator(
                                 updateState {
                                     it.copy(
                                         isPollingToken = false,
+                                        deviceCode = null,
+                                        userCode = null,
+                                        verificationUri = null,
                                         error = text(
                                             R.string.vm_auth_failed,
                                             arrayOf(tokenResp.error.orEmpty()),
@@ -138,7 +145,15 @@ class AuthOobeCoordinator(
                                     )
                                 }
                             }
-                            else -> updateState { it.copy(isPollingToken = false, error = tokenResp.error) }
+                            else -> updateState {
+                                it.copy(
+                                    isPollingToken = false,
+                                    deviceCode = null,
+                                    userCode = null,
+                                    verificationUri = null,
+                                    error = tokenResp.error,
+                                )
+                            }
                         }
                     }
                     is Result.Error -> delay(intervalSeconds * 1000)


### PR DESCRIPTION
> 说明：本 PR 最初还包含「设置页未登录行可点击重新登录」的修复，但该功能已由 #178 独立合并到 `dev`。为避免重复与冲突，本 PR 已变基到最新 `dev`，**仅保留 #178 未覆盖的登录页死路修复**。

## 问题

GitHub 设备码授权流程中，当返回 `expired_token`（码过期）或 `access_denied`（用户拒绝授权），乃至其它 poll 错误时，`AuthOobeCoordinator.pollToken` 只设置了错误信息，却**没有清空 `userCode`**。

而登录页「使用 GitHub 登录」按钮的显示条件是 `userCode == null`（AuthGateScreen.kt），于是按钮持续被隐藏。结果：用户停在登录页，看到一个**已过期的设备码 + 报错，但没有任何重试按钮**，只能清除应用数据才能再次登录——死路一条。

## 改动（仅 1 个文件）

`app/src/main/java/com/abk/kernel/viewmodel/AuthOobeCoordinator.kt`

1. **`pollToken` 错误分支**（`expired_token` / `access_denied` / 其它 `else`）：一并清空 `deviceCode / userCode / verificationUri`，使「使用 GitHub 登录」按钮重新出现，用户可直接重试。
2. **`enterOobeFlow`**（`openLoginOobe` / `openBuildOobe` 的公共入口）：重新进入 OOBE 时同样重置这些设备码字段 + `isPollingToken`，保证重开的登录页始终是干净状态（尤其是在上一次遗留过期码之后）。

## 测试说明

局部、低风险改动；引用的状态字段（`deviceCode/userCode/verificationUri/isPollingToken`）均已存在于 `MainUiState`。当前环境无 Android SDK，未执行 gradle 构建，建议合并前本地编译一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)