### PR TITLE
Harden artifact verification: path traversal, unbounded reads, run-id binding

### DIFF
--- a/app/src/main/java/com/abk/kernel/utils/ArtifactVerification.kt
+++ b/app/src/main/java/com/abk/kernel/utils/ArtifactVerification.kt
@@ -3,12 +3,14 @@ package com.abk.kernel.utils
 import com.abk.kernel.data.model.ArtifactType
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
 import java.security.PublicKey
 import java.security.Signature
 import java.util.Base64
 import java.util.Locale
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
 data class SignedBundleManifest(
@@ -41,6 +43,16 @@ object ArtifactVerification {
     const val MANIFEST_FILE_NAME: String = "ABK_BUNDLE_MANIFEST.json"
     const val SIGNATURE_FILE_NAME: String = "ABK_BUNDLE_MANIFEST.sig"
 
+    // Mirrors the CLI limits in cli/abk.py so both verifiers refuse the same
+    // oversized input instead of allocating it. These bound the read itself:
+    // the manifest and signature are read before the signature is checked, so
+    // an unbounded read here is reachable without any valid key.
+    const val MAX_MANIFEST_SIZE: Long = 1L * 1024 * 1024
+    const val MAX_SIGNATURE_SIZE: Long = 64L * 1024
+    const val MAX_PAYLOAD_SIZE: Long = 8L * 1024 * 1024 * 1024
+
+    private const val COPY_BUFFER_SIZE = 64 * 1024
+
     private val gson = Gson()
 
     fun requiresTrustedBundle(type: ArtifactType): Boolean = when (type) {
@@ -52,10 +64,12 @@ object ArtifactVerification {
     fun readBundleManifest(bundleFile: File): SignedBundleManifest? = runCatching {
         ZipFile(bundleFile).use { zip ->
             zip.getEntry(MANIFEST_FILE_NAME)?.let { manifestEntry ->
-                gson.fromJson(
-                    zip.getInputStream(manifestEntry).use { String(it.readBytes(), Charsets.UTF_8) },
-                    SignedBundleManifest::class.java
-                )
+                readEntryAtMost(zip, manifestEntry, MAX_MANIFEST_SIZE)?.let { manifestBytes ->
+                    gson.fromJson(
+                        String(manifestBytes, Charsets.UTF_8),
+                        SignedBundleManifest::class.java
+                    )
+                }
             }
         }
     }.getOrNull()
@@ -63,7 +77,8 @@ object ArtifactVerification {
     fun verifyBundleFile(
         bundleFile: File,
         expectedType: ArtifactType? = null,
-        publicKeyPem: String? = null
+        publicKeyPem: String? = null,
+        expectedRunId: Long? = null
     ): BundleVerificationResult {
         if (!bundleFile.isFile || !bundleFile.name.lowercase(Locale.ROOT).endsWith(".bundle.zip")) {
             return failureFor(
@@ -96,8 +111,20 @@ object ArtifactVerification {
                         "Missing $SIGNATURE_FILE_NAME",
                         BundleVerificationFailureReason.MISSING_SIGNATURE
                     )
-                val manifestBytes = zip.getInputStream(manifestEntry).use { it.readBytes() }
-                val signatureBytes = zip.getInputStream(signatureEntry).use { it.readBytes() }
+                val manifestBytes = readEntryAtMost(zip, manifestEntry, MAX_MANIFEST_SIZE)
+                    ?: return failureFor(
+                        bundleFile.name,
+                        expectedType,
+                        "$MANIFEST_FILE_NAME exceeds $MAX_MANIFEST_SIZE bytes",
+                        BundleVerificationFailureReason.OTHER
+                    )
+                val signatureBytes = readEntryAtMost(zip, signatureEntry, MAX_SIGNATURE_SIZE)
+                    ?: return failureFor(
+                        bundleFile.name,
+                        expectedType,
+                        "$SIGNATURE_FILE_NAME exceeds $MAX_SIGNATURE_SIZE bytes",
+                        BundleVerificationFailureReason.OTHER
+                    )
                 val manifest = gson.fromJson(String(manifestBytes, Charsets.UTF_8), SignedBundleManifest::class.java)
                 if (!verifyManifestSignature(publicKey, manifestBytes, signatureBytes)) {
                     return BundleVerificationResult(
@@ -114,13 +141,26 @@ object ArtifactVerification {
                 if (manifest.bundleName != bundleFile.name) {
                     return BundleVerificationResult(manifest, false, "Bundle filename mismatch")
                 }
+                // A signed bundle stays valid indefinitely unless it is bound to the run
+                // that produced it, so an older signed build can otherwise be replayed in
+                // place of a newer one. Sentinel ids (unknown, prebuilt) stay exempt.
+                if (expectedRunId != null && expectedRunId > 0L && manifest.runId != expectedRunId) {
+                    return BundleVerificationResult(manifest, false, "Bundle run id mismatch")
+                }
+                if (!isSafeZipMemberName(manifest.payloadName)) {
+                    return BundleVerificationResult(manifest, false, "Unsafe payload name ${manifest.payloadName}")
+                }
+                if (manifest.payloadSizeBytes < 0L || manifest.payloadSizeBytes > MAX_PAYLOAD_SIZE) {
+                    return BundleVerificationResult(manifest, false, "Payload size out of range")
+                }
                 val payloadEntry = zip.getEntry(manifest.payloadName)
                     ?: return BundleVerificationResult(manifest, false, "Missing payload entry ${manifest.payloadName}")
-                val payloadBytes = zip.getInputStream(payloadEntry).use { it.readBytes() }
-                if (payloadBytes.size.toLong() != manifest.payloadSizeBytes) {
+                val payload = digestEntry(zip, payloadEntry, MAX_PAYLOAD_SIZE)
+                    ?: return BundleVerificationResult(manifest, false, "Payload exceeds $MAX_PAYLOAD_SIZE bytes")
+                if (payload.size != manifest.payloadSizeBytes) {
                     return BundleVerificationResult(manifest, false, "Payload size mismatch")
                 }
-                if (sha256(payloadBytes) != normalizeDigest(manifest.payloadSha256)) {
+                if (payload.digest != normalizeDigest(manifest.payloadSha256)) {
                     return BundleVerificationResult(manifest, false, "Payload digest mismatch")
                 }
                 BundleVerificationResult(
@@ -141,6 +181,56 @@ object ArtifactVerification {
     }
 
     fun normalizeDigest(value: String): String = value.trim().lowercase(Locale.ROOT)
+
+    /** Rejects absolute paths, backslashes and traversal segments, as the CLI does. */
+    internal fun isSafeZipMemberName(name: String): Boolean {
+        if (name.isEmpty() || name.startsWith("/") || name.contains("\\")) return false
+        return name.split("/").none { it.isEmpty() || it == "." || it == ".." }
+    }
+
+    private data class EntryDigest(val digest: String, val size: Long)
+
+    /**
+     * Reads at most [limit] bytes from [entry], returning null past that. The declared
+     * size is only a hint, so the running total is what actually bounds the read.
+     */
+    private fun readEntryAtMost(zip: ZipFile, entry: ZipEntry, limit: Long): ByteArray? {
+        if (entry.size > limit) return null
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        val collected = ByteArrayOutputStream()
+        zip.getInputStream(entry).use { input ->
+            var total = 0L
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > limit) return null
+                collected.write(buffer, 0, read)
+            }
+        }
+        return collected.toByteArray()
+    }
+
+    /** Digests [entry] in chunks so the payload never has to fit in memory at once. */
+    private fun digestEntry(zip: ZipFile, entry: ZipEntry, limit: Long): EntryDigest? {
+        if (entry.size > limit) return null
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        var total = 0L
+        zip.getInputStream(entry).use { input ->
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                total += read
+                if (total > limit) return null
+                digest.update(buffer, 0, read)
+            }
+        }
+        return EntryDigest(
+            digest = digest.digest().joinToString("") { "%02x".format(it) },
+            size = total
+        )
+    }
 
     private fun verifyManifestSignature(publicKey: PublicKey, manifestBytes: ByteArray, signatureBytes: ByteArray): Boolean {
         val verifier = Signature.getInstance("SHA256withRSA")
@@ -181,6 +271,3 @@ object ArtifactVerification {
         failureReason = failureReason,
     )
 }
-
-private fun sha256(bytes: ByteArray): String =
-    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }

--- a/app/src/main/java/com/abk/kernel/utils/DownloadUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/DownloadUtils.kt
@@ -315,7 +315,7 @@ object DownloadUtils {
                         stageDir = createStageDir(context, "artifact-${safeFileName(artifact.name)}")
                         zipFile = File(requireNotNull(stageDir), "${safeFileName(artifact.name)}.zip")
                     } else {
-                        zipFile = File(targetRunDir, "${artifact.name}.zip")
+                        zipFile = File(targetRunDir, "${safeFileName(artifact.name)}.zip")
                     }
 
                     body.byteStream().use { input ->
@@ -401,7 +401,8 @@ object DownloadUtils {
                         ArtifactVerification.verifyBundleFile(
                             candidate,
                             type,
-                            ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey)
+                            ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey),
+                            expectedRunId = run?.id
                         )
                     } else {
                         null
@@ -654,7 +655,8 @@ object DownloadUtils {
                             ArtifactVerification.verifyBundleFile(
                                 candidate,
                                 type,
-                                ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey)
+                                ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey),
+                                expectedRunId = runId
                             )
                         }
                     } else {
@@ -850,7 +852,8 @@ object DownloadUtils {
                 ArtifactVerification.verifyBundleFile(
                     source,
                     effectiveType,
-                    ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey)
+                    ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey),
+                    expectedRunId = artifact.runId
                 )
             }
             if (!verification.success) {
@@ -1415,7 +1418,8 @@ object DownloadUtils {
         val verification = ArtifactVerification.verifyBundleFile(
             source,
             effectiveType,
-            ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey)
+            ForkSigningManager.publicKeyPemFromStoredValue(signingPublicKey),
+            expectedRunId = artifact.runId
         )
         if (verification.success) return null
         val kind = when (verification.failureReason) {

--- a/app/src/test/java/com/abk/kernel/utils/ArtifactVerificationTest.kt
+++ b/app/src/test/java/com/abk/kernel/utils/ArtifactVerificationTest.kt
@@ -1,0 +1,198 @@
+package com.abk.kernel.utils
+
+import com.abk.kernel.data.model.ArtifactType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.security.KeyFactory
+import java.security.MessageDigest
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+
+class ArtifactVerificationTest {
+
+    companion object {
+        // JUnit builds a fresh instance per test; keygen is slow enough to share.
+        private val material by lazy { ForkSigningManager.generateSigningMaterial() }
+    }
+
+    @Test
+    fun verifyBundleFile_acceptsWellFormedBundle() {
+        val bundle = writeSignedBundle(runId = 42L)
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem
+        )
+
+        assertTrue(result.message, result.success)
+    }
+
+    @Test
+    fun verifyBundleFile_rejectsRunIdMismatch() {
+        val bundle = writeSignedBundle(runId = 42L)
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem,
+            expectedRunId = 43L
+        )
+
+        assertFalse(result.success)
+        assertEquals("Bundle run id mismatch", result.message)
+    }
+
+    @Test
+    fun verifyBundleFile_acceptsMatchingRunId() {
+        val bundle = writeSignedBundle(runId = 42L)
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem,
+            expectedRunId = 42L
+        )
+
+        assertTrue(result.message, result.success)
+    }
+
+    /** Unknown (-1) and prebuilt (-2) sentinels must not start failing verification. */
+    @Test
+    fun verifyBundleFile_ignoresSentinelRunIds() {
+        val bundle = writeSignedBundle(runId = 42L)
+
+        listOf(-1L, -2L, 0L).forEach { sentinel ->
+            val result = ArtifactVerification.verifyBundleFile(
+                bundle,
+                ArtifactType.KERNEL_IMG,
+                material.publicKeyPem,
+                expectedRunId = sentinel
+            )
+            assertTrue("sentinel $sentinel should not gate verification", result.success)
+        }
+    }
+
+    /**
+     * The manifest is read before the signature is checked, so an oversized one has to
+     * be refused rather than allocated — no valid key is needed to reach this path.
+     */
+    @Test
+    fun verifyBundleFile_rejectsOversizedManifest() {
+        val oversized = ByteArray((ArtifactVerification.MAX_MANIFEST_SIZE + 1024L).toInt()) { ' '.code.toByte() }
+        val bundle = File(tempDir(), "oversized.bundle.zip")
+        ZipOutputStream(bundle.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry(ArtifactVerification.MANIFEST_FILE_NAME))
+            zip.write(oversized)
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry(ArtifactVerification.SIGNATURE_FILE_NAME))
+            zip.write(ByteArray(16))
+            zip.closeEntry()
+        }
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem
+        )
+
+        assertFalse(result.success)
+        assertTrue(result.message, result.message.contains("exceeds"))
+    }
+
+    @Test
+    fun verifyBundleFile_rejectsOversizedSignature() {
+        val bundle = writeSignedBundle(
+            runId = 42L,
+            signatureOverride = ByteArray((ArtifactVerification.MAX_SIGNATURE_SIZE + 1024L).toInt())
+        )
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem
+        )
+
+        assertFalse(result.success)
+        assertTrue(result.message, result.message.contains("exceeds"))
+    }
+
+    @Test
+    fun verifyBundleFile_rejectsTamperedPayload() {
+        val bundle = writeSignedBundle(runId = 42L, payloadOverride = "tampered".toByteArray())
+
+        val result = ArtifactVerification.verifyBundleFile(
+            bundle,
+            ArtifactType.KERNEL_IMG,
+            material.publicKeyPem
+        )
+
+        assertFalse(result.success)
+    }
+
+    @Test
+    fun isSafeZipMemberName_rejectsTraversalAndAbsolutePaths() {
+        listOf("../evil", "a/../../evil", "/etc/passwd", "a\\b", "", "./x", "a//b")
+            .forEach { assertFalse(it, ArtifactVerification.isSafeZipMemberName(it)) }
+
+        listOf("payload.img", "nested/payload.img", "a.b.c")
+            .forEach { assertTrue(it, ArtifactVerification.isSafeZipMemberName(it)) }
+    }
+
+    private fun tempDir(): File = createTempDirectory("artifact-verification").toFile()
+
+    private fun writeSignedBundle(
+        runId: Long,
+        payload: ByteArray = "kernel-image-bytes".toByteArray(),
+        payloadOverride: ByteArray? = null,
+        signatureOverride: ByteArray? = null
+    ): File {
+        val bundleName = "artifact.bundle.zip"
+        val bundle = File(tempDir(), bundleName)
+        val manifestJson = """
+            {"schema":1,"bundle_name":"$bundleName","artifact_type":"KERNEL_IMG",
+             "run_id":$runId,"payload_name":"payload.img",
+             "payload_sha256":"${sha256Hex(payload)}","payload_size_bytes":${payload.size}}
+        """.trimIndent()
+        val manifestBytes = manifestJson.toByteArray()
+
+        ZipOutputStream(bundle.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry(ArtifactVerification.MANIFEST_FILE_NAME))
+            zip.write(manifestBytes)
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry(ArtifactVerification.SIGNATURE_FILE_NAME))
+            zip.write(signatureOverride ?: sign(manifestBytes))
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("payload.img"))
+            zip.write(payloadOverride ?: payload)
+            zip.closeEntry()
+        }
+        return bundle
+    }
+
+    private fun sign(bytes: ByteArray): ByteArray {
+        val der = Base64.getDecoder().decode(
+            material.privateKeyPem
+                .lineSequence()
+                .filterNot { it.startsWith("-----") }
+                .joinToString("")
+                .trim()
+        )
+        val key = KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(der))
+        return Signature.getInstance("SHA256withRSA").run {
+            initSign(key)
+            update(bytes)
+            sign()
+        }
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}


### PR DESCRIPTION
Three fixes on the download → verify → flash path, plus unit tests. Each one closes a gap where the Kotlin app is weaker than the Python CLI doing the equivalent job.

## 1. Path traversal in the downloaded artifact filename

`DownloadUtils.downloadArtifact()` built the destination as `"${artifact.name}.zip"` in the non-bundled branch. `artifact.name` comes from the GitHub API for whatever repo the app is pointed at.

Every other use of it in that file already goes through `safeFileName()` — lines 311, 315, 316, 388, 814, 858, 878, 896. This one line was the exception, so a name containing traversal segments wrote outside the downloads root. The consistency everywhere else is what makes this look like an oversight rather than a deliberate choice.

Safe to change: the zip is deleted right after `unzip()`, and the helper used for matching, `artifactStorageFolderName()`, is itself `safeFileName()` — so the sanitized name is what the rest of the path already expects.

## 2. Unbounded reads in the Kotlin verifier

`ArtifactVerification` read the manifest, signature, and payload with `readBytes()` and no size limit anywhere. The CLI verifier in `cli/abk.py` has enforced `MAX_MANIFEST_SIZE` / `MAX_SIGNATURE_SIZE` / `MAX_PAYLOAD_SIZE` all along (`cli/abk.py:103-105`).

Two things made this worse than a generic OOM:

- The manifest and signature are read **before** `verifyManifestSignature()`, so the allocation was reachable without any valid key.
- The payload size check ran *after* the array was already materialized, so it protected nothing.

This ports the CLI limits over, bounds each read by the running byte total rather than trusting the declared entry size, and digests the payload in chunks so it never has to fit in memory at once.

`readBundleManifest()` had the same unbounded read and is called before verification in two places (`prepareDownloadedArtifact`, and the flash security prompt), so it is bounded too.

## 3. Signed bundles were never bound to their run

`manifest.run_id` was deserialized and then never compared to anything — `verifyBundleFile()` took no expected-run-id parameter at all. The CLI does exactly this check (`cli/abk.py:2632`).

Because one fork signing key signs every build, a correctly signed bundle from an older run stayed valid indefinitely. Anyone able to substitute the artifact response could serve a previous, legitimately signed kernel — including one built before a security fix — and the app would accept it.

Adds an optional `expectedRunId` and threads the producing run id in at the call sites that know it. **Enforcement is skipped for ids `<= 0`**, so the unknown (`-1`) and prebuilt GKI (`-2`) sentinels behave exactly as before — there is a test pinning that.

## Also included

The CLI's `_safe_zip_member_name` check is ported to the manifest's `payload_name`, since `prepareDownloadedArtifact` builds a file path from it (`File(extractDir, verification.manifest.payloadName)`). Flagging it explicitly as a fourth change rather than folding it in silently — it is small and mirrors the CLI, but it was not one of the three reported issues.

## Not changed

`inspectBundleVerification()` has no run id available from its caller (`persistBundledDownloadEntry`), so that listing path stays unbound and keeps its current behaviour. Adding a parameter that is always null would have been dead plumbing.

## Tests

New `ArtifactVerificationTest` covers: happy path, run-id mismatch rejected, matching run id accepted, sentinel run ids not gating, oversized manifest rejected, oversized signature rejected, tampered payload rejected, and traversal/absolute names rejected.

## Verification status

The three fixes and the tests were written against the code as read, but **I could not compile or run them** — this environment has no JVM or Gradle, so `./gradlew test` has not been executed. Please let CI confirm before merging.