### PR TITLE
fix(app): write patched boot images to the configured download directory

### DIFF
--- a/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
@@ -121,7 +121,8 @@ fun AbkRootPatchScreen(
     backgroundUri: String?,
     backgroundImageEnabled: Boolean,
     onBack: () -> Unit,
-    onBackEnabledChange: (Boolean) -> Unit = {}
+    onBackEnabledChange: (Boolean) -> Unit = {},
+    downloadDirectory: String? = null
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -377,7 +378,8 @@ fun AbkRootPatchScreen(
                     allowShell = allowShell,
                     enableAdb = enableAdb,
                     localModulePath = modulePath,
-                    onOutput = ::appendLog
+                    onOutput = ::appendLog,
+                    downloadDirectory = downloadDirectory
                 )
             }
             finishPatchResult(result)
@@ -409,7 +411,8 @@ fun AbkRootPatchScreen(
                     allowShell = allowShell,
                     enableAdb = enableAdb,
                     localModulePath = modulePath,
-                    onOutput = ::appendLog
+                    onOutput = ::appendLog,
+                    downloadDirectory = downloadDirectory
                 )
             }
             finishPatchResult(result)

--- a/app/src/main/java/com/abk/kernel/ui/screens/RuntimeScreens.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/RuntimeScreens.kt
@@ -260,6 +260,7 @@ fun RuntimeHomeScreen(
                     runtimeVariant = state.abkRuntimeStatus?.manager?.variant.orEmpty(),
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled,
+                    downloadDirectory = state.downloadDirectory,
                     onBack = childPageBack::requestDismiss,
                     onBackEnabledChange = { managerPatchBackEnabled = it }
                 )

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -476,7 +476,8 @@ object RootUtils {
         allowShell: Boolean = false,
         enableAdb: Boolean = false,
         localModulePath: String? = null,
-        onOutput: ((String) -> Unit)? = null
+        onOutput: ((String) -> Unit)? = null,
+        downloadDirectory: String? = null
     ): BootPatchResult {
         val sourceBoot = bootImagePath
             ?.takeIf { it.isNotBlank() }
@@ -511,10 +512,16 @@ object RootUtils {
                 stageBundledAbkLkmAsset(context, workDir, checkNotNull(asset))
             }
 
-            val outputDir = File(
-                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: context.filesDir,
-                "abk-patched"
-            ).apply { mkdirs() }
+            val outputDir = resolvePatchOutputDir(downloadDirectory)
+                ?: File(
+                    context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: context.filesDir,
+                    "abk-patched"
+                ).apply { mkdirs() }
+            // Flash-only modes (Direct Install/OTA) patch the partition in place and don't hand
+            // the user a patched image, so the output-dir line would be noise there.
+            if (!flash) {
+                onOutput?.invoke(tr(R.string.ru_log_output_dir, outputDir.absolutePath))
+            }
             val moduleName = (asset?.let { "${it.variantId}-${it.kmi}" } ?: moduleFile.nameWithoutExtension)
                 .replace(Regex("""[^A-Za-z0-9._-]"""), "_")
             val outputName = "abk-${moduleName}-patched-${System.currentTimeMillis()}.img"
@@ -2264,6 +2271,23 @@ object RootUtils {
         target.setReadable(true, false)
         target.setWritable(true, true)
         return target
+    }
+
+    /**
+     * Resolve the directory where patched boot images are written.
+     *
+     * Prefers the user-configured public download directory (Download/ABK/abk-patched),
+     * mirroring DownloadUtils.resolveDownloadsRoot semantics: normalize, create, then verify
+     * isDirectory && canWrite. Returns null when the public directory can't be created or isn't
+     * writable, so the caller falls back to app-scoped storage.
+     */
+    internal fun resolvePatchOutputDir(downloadDirectory: String?): File? {
+        val root = File(DownloadDirectoryUtils.normalizeDirectoryPath(downloadDirectory))
+        val rootReady = root.exists() || root.mkdirs()
+        if (!rootReady || !root.isDirectory || !root.canWrite()) return null
+        val subDir = File(root, "abk-patched")
+        if (!subDir.exists() && !subDir.mkdirs()) return null
+        return subDir.takeIf { it.isDirectory && it.canWrite() }
     }
 
     private fun buildBootPatchArgs(

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -21,6 +21,7 @@ import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
 import org.json.JSONObject
 import java.io.File
+import java.io.IOException
 import java.util.Collections
 import java.util.Properties
 import java.security.MessageDigest
@@ -512,11 +513,16 @@ object RootUtils {
                 stageBundledAbkLkmAsset(context, workDir, checkNotNull(asset))
             }
 
-            val outputDir = resolvePatchOutputDir(downloadDirectory)
-                ?: File(
-                    context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: context.filesDir,
-                    "abk-patched"
-                ).apply { mkdirs() }
+            val appScopedOutputCandidates = listOfNotNull(
+                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+                    ?.let { File(it, "abk-patched") },
+                File(context.filesDir, "abk-patched")
+            )
+            val outputDir = (if (flash) null else resolvePatchOutputDir(downloadDirectory))
+                ?: appScopedOutputCandidates.firstNotNullOfOrNull(::prepareWritableDirectory)
+                ?: throw IOException(
+                    tr(R.string.download_directory_create_failed, context.filesDir.absolutePath)
+                )
             // Flash-only modes (Direct Install/OTA) patch the partition in place and don't hand
             // the user a patched image, so the output-dir line would be noise there.
             if (!flash) {
@@ -2282,12 +2288,15 @@ object RootUtils {
      * writable, so the caller falls back to app-scoped storage.
      */
     internal fun resolvePatchOutputDir(downloadDirectory: String?): File? {
-        val root = File(DownloadDirectoryUtils.normalizeDirectoryPath(downloadDirectory))
-        val rootReady = root.exists() || root.mkdirs()
-        if (!rootReady || !root.isDirectory || !root.canWrite()) return null
-        val subDir = File(root, "abk-patched")
-        if (!subDir.exists() && !subDir.mkdirs()) return null
-        return subDir.takeIf { it.isDirectory && it.canWrite() }
+        val root = prepareWritableDirectory(
+            File(DownloadDirectoryUtils.normalizeDirectoryPath(downloadDirectory))
+        ) ?: return null
+        return prepareWritableDirectory(File(root, "abk-patched"))
+    }
+
+    private fun prepareWritableDirectory(directory: File): File? {
+        if (!directory.exists() && !directory.mkdirs()) return null
+        return directory.takeIf { it.isDirectory && it.canWrite() }
     }
 
     private fun buildBootPatchArgs(

--- a/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
+++ b/app/src/main/java/com/abk/kernel/utils/RootUtils.kt
@@ -523,8 +523,6 @@ object RootUtils {
                 ?: throw IOException(
                     tr(R.string.download_directory_create_failed, context.filesDir.absolutePath)
                 )
-            // Flash-only modes (Direct Install/OTA) patch the partition in place and don't hand
-            // the user a patched image, so the output-dir line would be noise there.
             if (!flash) {
                 onOutput?.invoke(tr(R.string.ru_log_output_dir, outputDir.absolutePath))
             }
@@ -2279,14 +2277,6 @@ object RootUtils {
         return target
     }
 
-    /**
-     * Resolve the directory where patched boot images are written.
-     *
-     * Prefers the user-configured public download directory (Download/ABK/abk-patched),
-     * mirroring DownloadUtils.resolveDownloadsRoot semantics: normalize, create, then verify
-     * isDirectory && canWrite. Returns null when the public directory can't be created or isn't
-     * writable, so the caller falls back to app-scoped storage.
-     */
     internal fun resolvePatchOutputDir(downloadDirectory: String?): File? {
         val root = prepareWritableDirectory(
             File(DownloadDirectoryUtils.normalizeDirectoryPath(downloadDirectory))

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1224,6 +1224,7 @@
     <string name="ru_lkm_module_not_bundled">No bundled LKM module for %1$s / %2$s</string>
     <string name="ru_log_using_bundled_lkm">[ABK] Using APK-bundled LKM: %1$s · %2$s</string>
     <string name="ru_log_using_local_lkm">[ABK] Using local LKM: %1$s</string>
+    <string name="ru_log_output_dir">[ABK] Output directory: %1$s</string>
     <string name="ru_log_no_root_shell_local_patch">[ABK] Root shell unavailable; falling back to APK-bundled SukiSU-Ultra ksud to patch the local boot image only</string>
     <string name="ru_no_embedded_ksud">No runnable APK-bundled SukiSU-Ultra ksud found; without root you can only generate a patched image after selecting boot.img.</string>
     <string name="ru_install_requires_root">This installation method requires root permission.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1223,6 +1223,7 @@
     <string name="ru_lkm_module_not_bundled">Нет встроенного LKM-модуля для %1$s / %2$s</string>
     <string name="ru_log_using_bundled_lkm">[ABK] Используется встроенный в APK LKM: %1$s · %2$s</string>
     <string name="ru_log_using_local_lkm">[ABK] Используется локальный LKM: %1$s</string>
+    <string name="ru_log_output_dir">[ABK] Каталог вывода: %1$s</string>
     <string name="ru_log_no_root_shell_local_patch">[ABK] Root shell недоступен — переходим на встроенный в APK SukiSU-Ultra ksud для патча только локального образа boot</string>
     <string name="ru_no_embedded_ksud">Исполняемый встроенный в APK SukiSU-Ultra ksud не найден; без root можно только сгенерировать пропатченный образ после выбора boot.img.</string>
     <string name="ru_install_requires_root">Этот способ установки требует прав root.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1296,6 +1296,7 @@
     <string name="ru_lkm_module_not_bundled">未内置 %1$s / %2$s 的 LKM 模块</string>
     <string name="ru_log_using_bundled_lkm">[ABK] 使用 APK 内置 LKM: %1$s · %2$s</string>
     <string name="ru_log_using_local_lkm">[ABK] 使用本地 LKM: %1$s</string>
+    <string name="ru_log_output_dir">[ABK] 输出目录: %1$s</string>
     <string name="ru_log_no_root_shell_local_patch">[ABK] Root shell 不可用，改用 APK 内置 SukiSU-Ultra ksud 仅修补本地 boot 镜像</string>
     <string name="ru_no_embedded_ksud">未找到可执行的 APK 内置 SukiSU-Ultra ksud；无 Root 时只能在选择 boot.img 后生成 patched 镜像。</string>
     <string name="ru_install_requires_root">该安装方式需要 Root 权限。</string>


### PR DESCRIPTION
## 背景

`patchAbkLkmBootImage`（ABK LKM boot/init_boot 修补流程）此前把产出的 patched `.img` 写到 app 私有外部目录 `Android/data/<pkg>/files/Download/abk-patched/`——文件管理器不可见、卸载即删，且与其它流程（下载/刷写走公共 `Download/ABK`）不一致。

## 改动

- 将 `MainUiState.downloadDirectory`（默认 `/storage/emulated/0/Download/ABK`）贯通 `RuntimeHomeScreen → AbkRootPatchScreen → patchAbkLkmBootImage`
- 输出目录改为三级优先链：公共 `downloadDirectory/abk-patched` → app 私有外部 `getExternalFilesDir(DOWNLOADS)/abk-patched` → 内部 `filesDir`，复用 `DownloadDirectoryUtils.normalizeDirectoryPath`，语义与 `DownloadUtils.resolveDownloadsRoot` 一致
- 仅在产出 patched 镜像的模式（非直接刷写）打印输出目录日志，避免 Direct Install / OTA 模式出现误导性提示

## 验收

- 修补后产物出现在 `Download/ABK/abk-patched/`，系统文件管理器可见
- 公共目录不可写时自动回退，无“所有文件访问”授权的用户不受影响
- root 路径以 app 进程 `canWrite()` 为准，保证最终 `outputImage.isFile` 校验与后续刷写能在 app 进程内执行
- `assembleDebug` 通过；完整单测 122 个中 8 个失败为 dev 既有基线（Robolectric 未 mock 等），与本改动无关
