### PR TITLE
feat(ui): Add Miuix blur and custom card backdrop blur support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -201,6 +201,9 @@ dependencies {
     // Preferences
     implementation(libs.datastore.preferences)
 
+    // Blur / glass
+    implementation(libs.miuix.blur)
+
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.ABK">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -91,7 +91,7 @@
         <activity
             android:name=".extensions.AbkExtensionManagerActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.ABK" />
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,14 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
-    <!-- Runtime shader blur is guarded in code while the app still supports API 26+. -->
+    <!--
+      The miuix-blur AAR declares minSdk 33 while this app supports API 26+. The override
+      keeps the build working; safety is enforced at runtime. Every path into the library
+      (rememberBlurBackdrop, blurSource, blurEffect, blurSourceBody, isBlurActive) is gated
+      on isRuntimeShaderSupported() (API 33+), and the AAR registers no ContentProvider or
+      initializer, so nothing library-side executes on API 26-32. Keep these guards intact
+      if the dependency version or call sites change.
+    -->
     <uses-sdk tools:overrideLibrary="top.yukonga.miuix.kmp.blur" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="adjustNothing"
             android:theme="@style/Theme.ABK">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -91,6 +91,7 @@
         <activity
             android:name=".extensions.AbkExtensionManagerActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustNothing"
             android:theme="@style/Theme.ABK" />
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -13,6 +14,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <!-- Runtime shader blur is guarded in code while the app still supports API 26+. -->
+    <uses-sdk tools:overrideLibrary="top.yukonga.miuix.kmp.blur" />
 
     <application
         android:name=".AbkApplication"

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
@@ -89,6 +90,12 @@ import com.abk.kernel.ui.components.AbkSnackbarHost
 import com.abk.kernel.ui.components.animateBottomNavForChildPage
 import com.abk.kernel.ui.components.showAbkSnackbar
 import com.abk.kernel.extensions.AbkExtensionBootstrapActivity
+import com.abk.kernel.ui.blur.LocalBlurState
+import com.abk.kernel.ui.blur.blurEffect
+import com.abk.kernel.ui.blur.blurSourceBody
+import com.abk.kernel.ui.blur.isBlurActive
+import com.abk.kernel.ui.blur.rememberBlurBackdrop
+import com.abk.kernel.ui.blur.rememberBlurBackgroundPainter
 import com.abk.kernel.ui.screens.BuildScreen
 import com.abk.kernel.ui.screens.FlashScreen
 import com.abk.kernel.ui.screens.InstalledModulesScreen
@@ -123,6 +130,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val vm: MainViewModel = viewModel()
             val state by vm.uiState.collectAsState()
+            val uiSurfaceAlphaPreview by vm.uiSurfaceAlphaPreview.collectAsState(initial = state.uiSurfaceAlpha)
             var extensionBootstrapIssued by rememberSaveable { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
@@ -161,7 +169,8 @@ class MainActivity : ComponentActivity() {
                 AppBackgroundHost(
                     backgroundUri = state.customBackgroundUri,
                     backgroundEnabled = state.backgroundImageEnabled,
-                    uiSurfaceAlpha = state.uiSurfaceAlpha
+                    uiSurfaceAlpha = uiSurfaceAlphaPreview,
+                    blurBackgroundEnabled = state.blurConfig.wantsBackgroundPainter,
                 ) {
                     when {
                         !state.termsLoaded -> Surface(
@@ -582,6 +591,21 @@ private fun AbkMainScaffold(
     }
     val navProgress = navProgressAnim.value
 
+    // The bottom NavigationBar/NavigationRail live outside every screen's
+    // BlurScreenScaffold, so they keep their own backdrop as the blur source.
+    val blurBackdrop = rememberBlurBackdrop(
+        enableBlur = state.blurConfig.blurEnabled,
+        surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
+        backgroundPainter = rememberBlurBackgroundPainter(state.blurConfig),
+    )
+
+    CompositionLocalProvider(
+        LocalBlurState provides blurBackdrop,
+    ) {
+        // Gate bar transparency on the frosted effect actually rendering (API >= 33),
+        // so pre-Android-13 devices fall back to the opaque surface color.
+        val blurActive = isBlurActive(state.blurEnabled)
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -603,8 +627,14 @@ private fun AbkMainScaffold(
                 contentAlignment = Alignment.Center
             ) {
                 NavigationRail(
-                    modifier = Modifier.fillMaxSize(),
-                    containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(if (blurActive) Modifier.blurEffect() else Modifier),
+                    containerColor = if (blurActive) {
+                        Color.Transparent
+                    } else {
+                        uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+                    }
                 ) {
                     visibleTabs.forEach { tab ->
                         NavigationRailItem(
@@ -650,8 +680,13 @@ private fun AbkMainScaffold(
                         val hidden = 1f - navProgress
                         translationY = hidden * bottomBarHeightPx
                         alpha = 1f - (hidden * 0.15f)
-                    },
-                containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer),
+                    }
+                    .then(if (blurActive) Modifier.blurEffect() else Modifier),
+                containerColor = if (blurActive) {
+                    Color.Transparent
+                } else {
+                    uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+                },
                 tonalElevation = 0.dp
             ) {
                 visibleTabs.forEach { tab ->
@@ -691,6 +726,7 @@ private fun AbkMainScaffold(
             modifier = Modifier
                 .fillMaxSize()
                 .zIndex(1f)
+                .blurSourceBody()
         ) {
             Box(
                 modifier = Modifier
@@ -788,6 +824,7 @@ private fun AbkMainScaffold(
                 .zIndex(4f)
         )
     }
+}
 }
 
 @Composable

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -93,6 +93,7 @@ import com.abk.kernel.extensions.AbkExtensionBootstrapActivity
 import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
 import com.abk.kernel.ui.blur.LocalBlurState
 import com.abk.kernel.ui.blur.LocalBlurredCardBackground
+import com.abk.kernel.ui.blur.LocalBlurredCardBackgroundEnabled
 import com.abk.kernel.ui.blur.blurEffect
 import com.abk.kernel.ui.blur.blurSourceBody
 import com.abk.kernel.ui.blur.isBlurActive
@@ -215,6 +216,7 @@ class MainActivity : ComponentActivity() {
                                 CompositionLocalProvider(
                                     LocalUiSurfaceAlpha provides 1f,
                                     LocalBlurredCardBackground provides null,
+                                    LocalBlurredCardBackgroundEnabled provides false,
                                     LocalBlurBackgroundAnchor provides null,
                                 ) {
                                     Box(

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -593,10 +593,19 @@ private fun AbkMainScaffold(
 
     // The bottom NavigationBar/NavigationRail live outside every screen's
     // BlurScreenScaffold, so they keep their own backdrop as the blur source.
+    // When a child page hides the bar (navProgress reaches 1) or the opaque OOBE
+    // overlay covers everything, neither the backdrop nor its blur pipeline has a
+    // visible consumer, so they are switched off to avoid an invisible full-screen
+    // recordLayer + AGSL blur pass every frame.
+    val barBlurOnScreen = !state.showOobe && navProgress < 1f
     val blurBackdrop = rememberBlurBackdrop(
-        enableBlur = state.blurConfig.blurEnabled,
+        enableBlur = state.blurConfig.blurEnabled && barBlurOnScreen,
         surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
-        backgroundPainter = rememberBlurBackgroundPainter(state.blurConfig),
+        backgroundPainter = if (barBlurOnScreen) {
+            rememberBlurBackgroundPainter(state.blurConfig)
+        } else {
+            null
+        },
     )
 
     CompositionLocalProvider(
@@ -604,7 +613,7 @@ private fun AbkMainScaffold(
     ) {
         // Gate bar transparency on the frosted effect actually rendering (API >= 33),
         // so pre-Android-13 devices fall back to the opaque surface color.
-        val blurActive = isBlurActive(state.blurEnabled)
+        val blurActive = isBlurActive(state.blurEnabled && barBlurOnScreen)
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -90,7 +90,9 @@ import com.abk.kernel.ui.components.AbkSnackbarHost
 import com.abk.kernel.ui.components.animateBottomNavForChildPage
 import com.abk.kernel.ui.components.showAbkSnackbar
 import com.abk.kernel.extensions.AbkExtensionBootstrapActivity
+import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
 import com.abk.kernel.ui.blur.LocalBlurState
+import com.abk.kernel.ui.blur.LocalBlurredCardBackground
 import com.abk.kernel.ui.blur.blurEffect
 import com.abk.kernel.ui.blur.blurSourceBody
 import com.abk.kernel.ui.blur.isBlurActive
@@ -207,7 +209,14 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
                             if (state.showOobe) {
-                                CompositionLocalProvider(LocalUiSurfaceAlpha provides 1f) {
+                                // OOBE is an opaque onboarding screen; clear the blur
+                                // locals so its cards render opaque instead of showing a
+                                // translucent frosted backdrop under the wallpaper.
+                                CompositionLocalProvider(
+                                    LocalUiSurfaceAlpha provides 1f,
+                                    LocalBlurredCardBackground provides null,
+                                    LocalBlurBackgroundAnchor provides null,
+                                ) {
                                     Box(
                                         modifier = Modifier
                                             .fillMaxSize()
@@ -591,13 +600,12 @@ private fun AbkMainScaffold(
     }
     val navProgress = navProgressAnim.value
 
-    // The bottom NavigationBar/NavigationRail live outside every screen's
-    // BlurScreenScaffold, so they keep their own backdrop as the blur source.
-    // When a child page hides the bar (navProgress reaches 1) or the opaque OOBE
-    // overlay covers everything, neither the backdrop nor its blur pipeline has a
-    // visible consumer, so they are switched off to avoid an invisible full-screen
-    // recordLayer + AGSL blur pass every frame.
-    val barBlurOnScreen = !state.showOobe && navProgress < 1f
+    // Bottom-nav progress goes 1f (bar shown) → 0f (a child page slides the bar off).
+    // Only run the bar backdrop and its blur pipeline while the bar is actually on
+    // screen; once it is fully hidden (matches ChildPageMotion's hide epsilon) or the
+    // opaque OOBE overlay covers everything, every recordLayer + blur pass is invisible,
+    // so it is switched off.
+    val barBlurOnScreen = !state.showOobe && navProgress > 0.02f
     val blurBackdrop = rememberBlurBackdrop(
         enableBlur = state.blurConfig.blurEnabled && barBlurOnScreen,
         surfaceColor = MaterialTheme.colorScheme.surfaceContainer,

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -128,9 +128,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // adjustResize keeps content above the IME; the card-blur backdrop keys its
-        // re-blur on width (not height), so a height-only IME resize does not re-run the
-        // decode + StackBlur pass.
         pendingModuleInstallUri = extractModuleInstallUri(intent)?.toString()
 
         setContent {

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -8,7 +8,6 @@ import com.abk.kernel.utils.findActivity
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.view.WindowManager
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -129,13 +128,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // adjustNothing keeps the window (and the frosted-backdrop layer) from resizing on
-        // IME so blur never re-runs for the keyboard, but Android 10 and below do not
-        // deliver full IME insets, so imePadding cannot lift content over the keyboard;
-        // fall back to adjustResize there.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        }
+        // adjustResize keeps content above the IME; the card-blur backdrop keys its
+        // re-blur on width (not height), so a height-only IME resize does not re-run the
+        // decode + StackBlur pass.
         pendingModuleInstallUri = extractModuleInstallUri(intent)?.toString()
 
         setContent {

--- a/app/src/main/java/com/abk/kernel/MainActivity.kt
+++ b/app/src/main/java/com/abk/kernel/MainActivity.kt
@@ -8,6 +8,7 @@ import com.abk.kernel.utils.findActivity
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.view.WindowManager
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -128,6 +129,13 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // adjustNothing keeps the window (and the frosted-backdrop layer) from resizing on
+        // IME so blur never re-runs for the keyboard, but Android 10 and below do not
+        // deliver full IME insets, so imePadding cannot lift content over the keyboard;
+        // fall back to adjustResize there.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
         pendingModuleInstallUri = extractModuleInstallUri(intent)?.toString()
 
         setContent {

--- a/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
@@ -13,6 +13,7 @@ import com.abk.kernel.data.model.normalizeAppUpdateStability
 import com.abk.kernel.utils.DownloadDirectoryUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -53,6 +54,8 @@ class PreferencesRepository(private val context: Context) {
         val KEY_CUSTOM_BACKGROUND_URI = stringPreferencesKey("custom_background_uri")
         val KEY_BACKGROUND_IMAGE_ENABLED = booleanPreferencesKey("background_image_enabled")
         val KEY_UI_SURFACE_ALPHA = floatPreferencesKey("ui_surface_alpha")
+        val KEY_BLUR_ENABLED = booleanPreferencesKey("blur_enabled")
+        val KEY_BLUR_BACKGROUND_EXP_ENABLED = booleanPreferencesKey("blur_background_exp_enabled")
         val KEY_BUILD_CONFIG = stringPreferencesKey("build_config_json")
         val KEY_BUILD_PLANS = stringPreferencesKey("build_plans_json")
         val KEY_BUILD_QUEUE = stringPreferencesKey("build_queue_json")
@@ -105,9 +108,16 @@ class PreferencesRepository(private val context: Context) {
     val dynamicColorEnabled: Flow<Boolean> = context.dataStore.data.map { it[KEY_DYNAMIC_COLOR_ENABLED] ?: true }
     val customThemeColorArgb: Flow<Int?> = context.dataStore.data.map { it[KEY_CUSTOM_THEME_COLOR] }
     val customAccentColorArgb: Flow<Int?> = context.dataStore.data.map { it[KEY_CUSTOM_ACCENT_COLOR] }
-    val customBackgroundUri: Flow<String?> = context.dataStore.data.map { it[KEY_CUSTOM_BACKGROUND_URI] }
-    val backgroundImageEnabled: Flow<Boolean> = context.dataStore.data.map { it[KEY_BACKGROUND_IMAGE_ENABLED] ?: false }
-    val uiSurfaceAlpha: Flow<Float> = context.dataStore.data.map { it[KEY_UI_SURFACE_ALPHA] ?: 1f }
+    val customBackgroundUri: Flow<String?> =
+        context.dataStore.data.map { it[KEY_CUSTOM_BACKGROUND_URI] }.distinctUntilChanged()
+    val backgroundImageEnabled: Flow<Boolean> =
+        context.dataStore.data.map { it[KEY_BACKGROUND_IMAGE_ENABLED] ?: false }.distinctUntilChanged()
+    val uiSurfaceAlpha: Flow<Float> =
+        context.dataStore.data.map { it[KEY_UI_SURFACE_ALPHA] ?: 1f }.distinctUntilChanged()
+    val blurEnabled: Flow<Boolean> =
+        context.dataStore.data.map { it[KEY_BLUR_ENABLED] ?: true }.distinctUntilChanged()
+    val blurBackgroundExpEnabled: Flow<Boolean> =
+        context.dataStore.data.map { it[KEY_BLUR_BACKGROUND_EXP_ENABLED] ?: false }.distinctUntilChanged()
     val buildConfigJson: Flow<String?> = context.dataStore.data.map { it[KEY_BUILD_CONFIG] }
     val buildPlansJson: Flow<String?> = context.dataStore.data.map { it[KEY_BUILD_PLANS] }
     val buildQueueJson: Flow<String?> = context.dataStore.data.map { it[KEY_BUILD_QUEUE] }
@@ -246,6 +256,13 @@ class PreferencesRepository(private val context: Context) {
     }
     suspend fun setUiSurfaceAlpha(alpha: Float) = context.dataStore.edit {
         it[KEY_UI_SURFACE_ALPHA] = alpha.coerceIn(0f, 1f)
+    }
+    suspend fun setBlurEnabled(v: Boolean) = context.dataStore.edit {
+        it[KEY_BLUR_ENABLED] = v
+        if (!v) it[KEY_BLUR_BACKGROUND_EXP_ENABLED] = false
+    }
+    suspend fun setBlurBackgroundExpEnabled(v: Boolean) = context.dataStore.edit {
+        it[KEY_BLUR_BACKGROUND_EXP_ENABLED] = v
     }
     suspend fun saveBuildConfigJson(json: String) = context.dataStore.edit { it[KEY_BUILD_CONFIG] = json }
     suspend fun saveBuildPlansJson(json: String) = context.dataStore.edit { it[KEY_BUILD_PLANS] = json }

--- a/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/abk/kernel/data/repository/PreferencesRepository.kt
@@ -259,7 +259,6 @@ class PreferencesRepository(private val context: Context) {
     }
     suspend fun setBlurEnabled(v: Boolean) = context.dataStore.edit {
         it[KEY_BLUR_ENABLED] = v
-        if (!v) it[KEY_BLUR_BACKGROUND_EXP_ENABLED] = false
     }
     suspend fun setBlurBackgroundExpEnabled(v: Boolean) = context.dataStore.edit {
         it[KEY_BLUR_BACKGROUND_EXP_ENABLED] = v

--- a/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
+++ b/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
@@ -1,9 +1,7 @@
 package com.abk.kernel.extensions
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
-import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -83,11 +81,6 @@ class AbkExtensionManagerActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Same adjustNothing setup as MainActivity; fall back to adjustResize below
-        // Android 11 where full IME insets are not delivered to imePadding.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        }
         val focusExtensionId = intent.getStringExtra(ABK_EXTENSION_EXTRA_ID)
         val bootstrapMode = intent.getBooleanExtra("bootstrap_mode", false)
 

--- a/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
+++ b/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
@@ -1,7 +1,9 @@
 package com.abk.kernel.extensions
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -81,6 +83,11 @@ class AbkExtensionManagerActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Same adjustNothing setup as MainActivity; fall back to adjustResize below
+        // Android 11 where full IME insets are not delivered to imePadding.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
         val focusExtensionId = intent.getStringExtra(ABK_EXTENSION_EXTRA_ID)
         val bootstrapMode = intent.getBooleanExtra("bootstrap_mode", false)
 

--- a/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
+++ b/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -51,12 +50,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.abk.kernel.R
 import com.abk.kernel.data.repository.PreferencesRepository
+import com.abk.kernel.ui.blur.BlurConfig
+import com.abk.kernel.ui.blur.BlurScreenScaffold
 import com.abk.kernel.ui.components.AbkCenteredLoadingTransition
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AppBackgroundHost
@@ -91,6 +93,8 @@ class AbkExtensionManagerActivity : ComponentActivity() {
             val customBackgroundUri by prefs.customBackgroundUri.collectAsState(initial = null)
             val backgroundImageEnabled by prefs.backgroundImageEnabled.collectAsState(initial = false)
             val uiSurfaceAlpha by prefs.uiSurfaceAlpha.collectAsState(initial = 1f)
+            val blurEnabled by prefs.blurEnabled.collectAsState(initial = true)
+            val blurBackgroundExpEnabled by prefs.blurBackgroundExpEnabled.collectAsState(initial = false)
 
             AbkTheme(
                 themeMode = themeMode,
@@ -101,13 +105,21 @@ class AbkExtensionManagerActivity : ComponentActivity() {
                 AppBackgroundHost(
                     backgroundUri = customBackgroundUri,
                     backgroundEnabled = backgroundImageEnabled,
-                    uiSurfaceAlpha = uiSurfaceAlpha
+                    uiSurfaceAlpha = uiSurfaceAlpha,
+                    blurBackgroundEnabled = blurEnabled &&
+                        blurBackgroundExpEnabled &&
+                        backgroundImageEnabled &&
+                        !customBackgroundUri.isNullOrBlank(),
                 ) {
                     AbkExtensionManagerScreen(
                         focusExtensionId = focusExtensionId,
                         bootstrapMode = bootstrapMode,
                     onBack = ::finish,
                     onExternalFlowLaunched = ::finish,
+                    blurEnabled = blurEnabled,
+                    blurBackgroundExpEnabled = blurBackgroundExpEnabled,
+                    backgroundUri = customBackgroundUri,
+                    backgroundImageEnabled = backgroundImageEnabled,
                 )
             }
         }
@@ -122,6 +134,10 @@ fun AbkExtensionManagerScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     containerColor: Color = Color.Transparent,
+    blurEnabled: Boolean = false,
+    blurBackgroundExpEnabled: Boolean = false,
+    backgroundUri: String? = null,
+    backgroundImageEnabled: Boolean = false,
     onExternalFlowLaunched: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -269,7 +285,13 @@ fun AbkExtensionManagerScreen(
         return
     }
 
-    Scaffold(
+    BlurScreenScaffold(
+        blurConfig = BlurConfig(
+            blurEnabled = blurEnabled,
+            backgroundExpEnabled = blurBackgroundExpEnabled,
+            backgroundUri = backgroundUri,
+            backgroundImageEnabled = backgroundImageEnabled,
+        ),
         modifier = modifier,
         containerColor = containerColor,
         topBar = {
@@ -293,6 +315,7 @@ fun AbkExtensionManagerScreen(
                         }
                     }
                 },
+                enableBlur = blurEnabled,
                 actions = {
                     IconButton(onClick = ::requestRefresh) {
                         Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.refresh))
@@ -300,21 +323,24 @@ fun AbkExtensionManagerScreen(
                 }
             )
         }
-    ) { padding ->
+    ) { topBarHeight ->
         if (loading) {
             AbkCenteredLoadingTransition(
                 text = stringResource(R.string.loading),
-                modifier = Modifier.padding(padding)
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = topBarHeight + 16.dp)
             )
-            return@Scaffold
+            return@BlurScreenScaffold
         }
 
         if (extensions.isEmpty()) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding)
-                    .padding(horizontal = AbkScreenHorizontalPadding, vertical = 16.dp),
+                    .padding(top = topBarHeight + 16.dp)
+                    .padding(horizontal = AbkScreenHorizontalPadding)
+                    .padding(bottom = 16.dp),
                 verticalArrangement = Arrangement.Top
             ) {
                 ExpressiveSectionCard(
@@ -324,16 +350,14 @@ fun AbkExtensionManagerScreen(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 ) {}
             }
-            return@Scaffold
+            return@BlurScreenScaffold
         }
 
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
+            modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
                 start = AbkScreenHorizontalPadding,
-                top = 16.dp,
+                top = topBarHeight + 16.dp,
                 end = AbkScreenHorizontalPadding,
                 bottom = 80.dp
             ),

--- a/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
+++ b/app/src/main/java/com/abk/kernel/extensions/AbkExtensionManagerActivity.kt
@@ -95,6 +95,19 @@ class AbkExtensionManagerActivity : ComponentActivity() {
             val uiSurfaceAlpha by prefs.uiSurfaceAlpha.collectAsState(initial = 1f)
             val blurEnabled by prefs.blurEnabled.collectAsState(initial = true)
             val blurBackgroundExpEnabled by prefs.blurBackgroundExpEnabled.collectAsState(initial = false)
+            val blurConfig = remember(
+                customBackgroundUri,
+                backgroundImageEnabled,
+                blurEnabled,
+                blurBackgroundExpEnabled
+            ) {
+                BlurConfig(
+                    blurEnabled = blurEnabled,
+                    backgroundExpEnabled = blurBackgroundExpEnabled,
+                    backgroundUri = customBackgroundUri,
+                    backgroundImageEnabled = backgroundImageEnabled,
+                )
+            }
 
             AbkTheme(
                 themeMode = themeMode,
@@ -106,10 +119,7 @@ class AbkExtensionManagerActivity : ComponentActivity() {
                     backgroundUri = customBackgroundUri,
                     backgroundEnabled = backgroundImageEnabled,
                     uiSurfaceAlpha = uiSurfaceAlpha,
-                    blurBackgroundEnabled = blurEnabled &&
-                        blurBackgroundExpEnabled &&
-                        backgroundImageEnabled &&
-                        !customBackgroundUri.isNullOrBlank(),
+                    blurBackgroundEnabled = blurConfig.wantsBackgroundPainter,
                 ) {
                     AbkExtensionManagerScreen(
                         focusExtensionId = focusExtensionId,

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
@@ -1,6 +1,5 @@
 package com.abk.kernel.ui.blur
 
-import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Size
@@ -23,6 +22,13 @@ import kotlin.math.max
 
 internal const val AbkBlurRadius = 25f
 internal const val AbkBlurBackgroundDim = 0.35f
+
+/**
+ * Caps the surface tint applied over the frosted-glass backdrop. Keeping this below
+ * 1 keeps the blur visible even when [LocalUiSurfaceAlpha] is at its default 1f
+ * (no custom background, or background at 100% opacity).
+ */
+internal const val AbkBlurTintAlpha = 0.85f
 
 /** Creates a [LayerBackdrop] capturing content drawn beneath blurred bars. */
 @Composable
@@ -69,7 +75,9 @@ private fun ContentDrawScope.drawCroppedPainter(painter: Painter) {
 /** Marks content as the blur source for the active backdrop. */
 @Composable
 fun Modifier.blurSource(): Modifier {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+    // layerBackdrop needs AGSL runtime shaders (API 33+). Gating on the real
+    // capability instead of a lower SDK constant keeps the fallback accurate.
+    if (!isBlurCapableDevice()) return this
     return LocalBlurState.current?.let { backdrop ->
         this.then(Modifier.layerBackdrop(backdrop))
     } ?: this
@@ -78,11 +86,14 @@ fun Modifier.blurSource(): Modifier {
 /** Applies a frosted-glass effect using the active backdrop. */
 @Composable
 fun Modifier.blurEffect(blendColor: Color = Color.Unspecified): Modifier {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+    // textureBlur needs AGSL runtime shaders (API 33+).
+    if (!isBlurCapableDevice()) return this
     return LocalBlurState.current?.let { backdrop ->
         val effective = if (blendColor == Color.Unspecified) {
             MaterialTheme.colorScheme.surfaceContainer.copy(
-                alpha = LocalUiSurfaceAlpha.current.coerceIn(0f, 1f)
+                // Decoupled from LocalUiSurfaceAlpha so the frosted glass stays
+                // visible at the default opaque surface alpha (see AbkBlurTintAlpha).
+                alpha = (LocalUiSurfaceAlpha.current * AbkBlurTintAlpha).coerceIn(0f, 1f)
             )
         } else {
             blendColor

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
@@ -24,15 +24,7 @@ import kotlin.math.max
 internal const val AbkBlurRadius = 25f
 internal const val AbkBlurBackgroundDim = 0.35f
 
-/**
- * Creates a [LayerBackdrop] capturing the content drawn beneath the blurred bars.
- *
- * The draw callback first paints an optional background [Painter] (the custom
- * background image, when enabled), then a dimmed surface base for contrast, then the
- * content that will be captured as the blur source. Returns `null` when blur is
- * disabled or the device cannot run the frosted-glass shader (API < 33), in which
- * case the app falls back to opaque surfaces.
- */
+/** Creates a [LayerBackdrop] capturing content drawn beneath blurred bars. */
 @Composable
 fun rememberBlurBackdrop(
     enableBlur: Boolean,
@@ -74,12 +66,7 @@ private fun ContentDrawScope.drawCroppedPainter(painter: Painter) {
     }
 }
 
-/**
- * Marks content as the blur source for the active backdrop.
- *
- * Attach to the page content box (inside the Scaffold body, not the bar itself) so
- * that content scrolling beneath the bars is captured and blurred.
- */
+/** Marks content as the blur source for the active backdrop. */
 @Composable
 fun Modifier.blurSource(): Modifier {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
@@ -88,16 +75,7 @@ fun Modifier.blurSource(): Modifier {
     } ?: this
 }
 
-/**
- * Applies a frosted-glass effect to a bar using the active backdrop.
- *
- * Attach to a top/bottom bar whose container color is [Color.Transparent] when the
- * backdrop is active, so the blurred content shows through.
- *
- * @param blendColor Optional tint blended over the blurred content. Defaults to the
- * theme's surfaceContainer using the live "界面不透明度" value directly, matching
- * the card tint and ReSukiSU's card-alpha behavior.
- */
+/** Applies a frosted-glass effect using the active backdrop. */
 @Composable
 fun Modifier.blurEffect(blendColor: Color = Color.Unspecified): Modifier {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
@@ -1,0 +1,125 @@
+package com.abk.kernel.ui.blur
+
+import android.os.Build
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.painter.Painter
+import top.yukonga.miuix.kmp.blur.BlendColorEntry
+import top.yukonga.miuix.kmp.blur.BlurColors
+import top.yukonga.miuix.kmp.blur.LayerBackdrop
+import top.yukonga.miuix.kmp.blur.layerBackdrop
+import top.yukonga.miuix.kmp.blur.rememberLayerBackdrop
+import top.yukonga.miuix.kmp.blur.textureBlur
+import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
+import kotlin.math.max
+
+internal const val AbkBlurRadius = 25f
+internal const val AbkBlurBackgroundDim = 0.35f
+
+/**
+ * Creates a [LayerBackdrop] capturing the content drawn beneath the blurred bars.
+ *
+ * The draw callback first paints an optional background [Painter] (the custom
+ * background image, when enabled), then a dimmed surface base for contrast, then the
+ * content that will be captured as the blur source. Returns `null` when blur is
+ * disabled or the device cannot run the frosted-glass shader (API < 33), in which
+ * case the app falls back to opaque surfaces.
+ */
+@Composable
+fun rememberBlurBackdrop(
+    enableBlur: Boolean,
+    surfaceColor: Color,
+    backgroundPainter: Painter? = null,
+    backgroundDim: Float = AbkBlurBackgroundDim,
+): LayerBackdrop? {
+    if (!enableBlur || !isBlurCapableDevice()) return null
+    return rememberLayerBackdrop {
+        if (backgroundPainter != null) {
+            drawCroppedPainter(backgroundPainter)
+        } else {
+            drawRect(surfaceColor)
+        }
+        drawRect(surfaceColor.copy(alpha = backgroundDim))
+        drawContent()
+    }
+}
+
+private fun ContentDrawScope.drawCroppedPainter(painter: Painter) {
+    val targetSize = drawContext.size
+    val sourceSize = painter.intrinsicSize
+    if (!sourceSize.isSpecified || sourceSize.width <= 0f || sourceSize.height <= 0f) {
+        with(painter) { draw(size = targetSize) }
+        return
+    }
+
+    val scale = max(
+        targetSize.width / sourceSize.width,
+        targetSize.height / sourceSize.height,
+    )
+    val scaledSize = Size(sourceSize.width * scale, sourceSize.height * scale)
+    val left = (targetSize.width - scaledSize.width) / 2f
+    val top = (targetSize.height - scaledSize.height) / 2f
+    clipRect {
+        translate(left = left, top = top) {
+            with(painter) { draw(size = scaledSize) }
+        }
+    }
+}
+
+/**
+ * Marks content as the blur source for the active backdrop.
+ *
+ * Attach to the page content box (inside the Scaffold body, not the bar itself) so
+ * that content scrolling beneath the bars is captured and blurred.
+ */
+@Composable
+fun Modifier.blurSource(): Modifier {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+    return LocalBlurState.current?.let { backdrop ->
+        this.then(Modifier.layerBackdrop(backdrop))
+    } ?: this
+}
+
+/**
+ * Applies a frosted-glass effect to a bar using the active backdrop.
+ *
+ * Attach to a top/bottom bar whose container color is [Color.Transparent] when the
+ * backdrop is active, so the blurred content shows through.
+ *
+ * @param blendColor Optional tint blended over the blurred content. Defaults to the
+ * theme's surfaceContainer using the live "界面不透明度" value directly, matching
+ * the card tint and ReSukiSU's card-alpha behavior.
+ */
+@Composable
+fun Modifier.blurEffect(blendColor: Color = Color.Unspecified): Modifier {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+    return LocalBlurState.current?.let { backdrop ->
+        val effective = if (blendColor == Color.Unspecified) {
+            MaterialTheme.colorScheme.surfaceContainer.copy(
+                alpha = LocalUiSurfaceAlpha.current.coerceIn(0f, 1f)
+            )
+        } else {
+            blendColor
+        }
+        this.then(
+            Modifier.textureBlur(
+                backdrop = backdrop,
+                shape = RectangleShape,
+                blurRadius = AbkBlurRadius,
+                colors = BlurColors(
+                    blendColors = listOf(
+                        BlendColorEntry(color = effective),
+                    ),
+                ),
+            )
+        )
+    } ?: this
+}

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackdrop.kt
@@ -42,10 +42,12 @@ fun rememberBlurBackdrop(
     return rememberLayerBackdrop {
         if (backgroundPainter != null) {
             drawCroppedPainter(backgroundPainter)
+            // Dim the wallpaper so it blends into the surface tone behind the bar.
+            drawRect(surfaceColor.copy(alpha = backgroundDim))
         } else {
+            // Opaque fallback; a dim overlay on it would be a no-op.
             drawRect(surfaceColor)
         }
-        drawRect(surfaceColor.copy(alpha = backgroundDim))
         drawContent()
     }
 }

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
@@ -1,0 +1,23 @@
+package com.abk.kernel.ui.blur
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.rememberAsyncImagePainter
+
+/**
+ * Returns the custom background image as a [Painter] to be drawn into the blur
+ * backdrop, so the background becomes part of the frosted-glass source.
+ *
+ * Returns `null` when the background feature is disabled, the URI is empty, or
+ * background-into-blur is turned off. Uses Coil (same cache/decoder as
+ * [com.abk.kernel.ui.components.AppBackgroundHost]).
+ */
+@Composable
+fun rememberBlurBackgroundPainter(config: BlurConfig): Painter? {
+    if (!config.wantsBackgroundPainter) return null
+    return rememberAsyncImagePainter(
+        model = config.backgroundUri,
+        contentScale = ContentScale.Crop,
+    )
+}

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
@@ -5,14 +5,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.rememberAsyncImagePainter
 
-/**
- * Returns the custom background image as a [Painter] to be drawn into the blur
- * backdrop, so the background becomes part of the frosted-glass source.
- *
- * Returns `null` when the background feature is disabled, the URI is empty, or
- * background-into-blur is turned off. Uses Coil (same cache/decoder as
- * [com.abk.kernel.ui.components.AppBackgroundHost]).
- */
+/** Returns the custom background image painter for the blur backdrop. */
 @Composable
 fun rememberBlurBackgroundPainter(config: BlurConfig): Painter? {
     if (!config.wantsBackgroundPainter) return null

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurBackgroundPainter.kt
@@ -1,16 +1,25 @@
 package com.abk.kernel.ui.blur
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.rememberAsyncImagePainter
+
+/**
+ * Shared custom-background painter, provided by [com.abk.kernel.ui.components.AppBackgroundHost]
+ * which already renders it. Blur hosts reuse it so the same URI decodes once instead of
+ * once per screen scaffold (N+1 Coil requests for the same image).
+ */
+val LocalBlurredBackgroundPainter = compositionLocalOf<Painter?> { null }
 
 /** Returns the custom background image painter for the blur backdrop. */
 @Composable
 fun rememberBlurBackgroundPainter(config: BlurConfig): Painter? {
     if (!config.wantsBackgroundPainter) return null
-    return rememberAsyncImagePainter(
-        model = config.backgroundUri,
-        contentScale = ContentScale.Crop,
-    )
+    return LocalBlurredBackgroundPainter.current
+        ?: rememberAsyncImagePainter(
+            model = config.backgroundUri,
+            contentScale = ContentScale.Crop,
+        )
 }

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurHost.kt
@@ -1,0 +1,46 @@
+package com.abk.kernel.ui.blur
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.material3.MaterialTheme
+
+/**
+ * Creates a [LocalBlurState] backdrop for a screen and exposes it to its content.
+ *
+ * Wrap a screen's scaffold in this composable. The screen attaches
+ * [Modifier.blurSource] to its **body** content root (the part that scrolls beneath
+ * the bars) so it is captured as the blur source, and passes `enableBlur = true` to
+ * its top bar so the bar applies [Modifier.blurEffect].
+ *
+ * The backdrop MUST NOT include the bars themselves (that would blur the bars onto
+ * themselves and crash the render thread), so [Modifier.blurSource] goes on the body
+ * only, never on a container that wraps the top bar. When blur is disabled or
+ * unsupported this is a no-op passthrough.
+ */
+@Composable
+fun BlurHost(
+    blurConfig: BlurConfig,
+    content: @Composable () -> Unit,
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
+    val backgroundPainter = rememberBlurBackgroundPainter(blurConfig)
+    val backdrop = rememberBlurBackdrop(
+        enableBlur = blurConfig.blurEnabled,
+        surfaceColor = surfaceColor,
+        backgroundPainter = backgroundPainter,
+    )
+    CompositionLocalProvider(LocalBlurState provides backdrop) {
+        content()
+    }
+}
+
+/**
+ * Attaches the active backdrop's blur source to a screen's body content.
+ *
+ * Use as the root modifier of a screen's scaffold body (the content that scrolls
+ * beneath the bars). No-op when no backdrop is provided.
+ */
+@Composable
+fun Modifier.blurSourceBody(): Modifier =
+    if (LocalBlurState.current != null) this.blurSource() else this

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurHost.kt
@@ -5,19 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.MaterialTheme
 
-/**
- * Creates a [LocalBlurState] backdrop for a screen and exposes it to its content.
- *
- * Wrap a screen's scaffold in this composable. The screen attaches
- * [Modifier.blurSource] to its **body** content root (the part that scrolls beneath
- * the bars) so it is captured as the blur source, and passes `enableBlur = true` to
- * its top bar so the bar applies [Modifier.blurEffect].
- *
- * The backdrop MUST NOT include the bars themselves (that would blur the bars onto
- * themselves and crash the render thread), so [Modifier.blurSource] goes on the body
- * only, never on a container that wraps the top bar. When blur is disabled or
- * unsupported this is a no-op passthrough.
- */
+/** Provides a [LocalBlurState] backdrop to screen content. */
 @Composable
 fun BlurHost(
     blurConfig: BlurConfig,
@@ -35,12 +23,7 @@ fun BlurHost(
     }
 }
 
-/**
- * Attaches the active backdrop's blur source to a screen's body content.
- *
- * Use as the root modifier of a screen's scaffold body (the content that scrolls
- * beneath the bars). No-op when no backdrop is provided.
- */
+/** Attaches active backdrop's blur source to body content. */
 @Composable
 fun Modifier.blurSourceBody(): Modifier =
     if (LocalBlurState.current != null) this.blurSource() else this

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurScreenScaffold.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurScreenScaffold.kt
@@ -14,30 +14,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
-/**
- * A screen scaffold that hosts a [LocalBlurState] backdrop for frosted-glass bars.
- *
- * The body backdrop is laid out full-screen from y=0 while its content keeps the
- * horizontal and bottom safe-drawing insets, so the top-bar region has content to
- * blur. The [topBar] is drawn as a floating overlay **outside** the backdrop's
- * capture region; if the top bar were inside the captured content, its own blur
- * would sample itself and crash the render thread (SIGSEGV).
- *
- * The top bar is measured with a [SubcomposeLayout] before the body, so the body
- * receives the real bar height on its first layout pass.
- *
- * Screens call it with a body that scrolls full-screen and reserves the bar height
- * via a leading [androidx.compose.foundation.layout.Spacer].
- *
- * @param blurConfig Blur preferences for this screen.
- * @param containerColor Background color of the scaffold.
- * @param topBar Floating top bar overlay (draws above the content, outside the backdrop).
- * @param content Body inside horizontal/bottom safe-drawing insets; receives the
- * measured [topBar] height so it can insert a leading Spacer instead of applying
- * top layout padding.
- */
+/** Screen scaffold hosting a [LocalBlurState] backdrop for frosted-glass bars. */
 @Composable
 fun BlurScreenScaffold(
     blurConfig: BlurConfig,

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurScreenScaffold.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurScreenScaffold.kt
@@ -1,0 +1,81 @@
+package com.abk.kernel.ui.blur
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A screen scaffold that hosts a [LocalBlurState] backdrop for frosted-glass bars.
+ *
+ * The body backdrop is laid out full-screen from y=0 while its content keeps the
+ * horizontal and bottom safe-drawing insets, so the top-bar region has content to
+ * blur. The [topBar] is drawn as a floating overlay **outside** the backdrop's
+ * capture region; if the top bar were inside the captured content, its own blur
+ * would sample itself and crash the render thread (SIGSEGV).
+ *
+ * The top bar is measured with a [SubcomposeLayout] before the body, so the body
+ * receives the real bar height on its first layout pass.
+ *
+ * Screens call it with a body that scrolls full-screen and reserves the bar height
+ * via a leading [androidx.compose.foundation.layout.Spacer].
+ *
+ * @param blurConfig Blur preferences for this screen.
+ * @param containerColor Background color of the scaffold.
+ * @param topBar Floating top bar overlay (draws above the content, outside the backdrop).
+ * @param content Body inside horizontal/bottom safe-drawing insets; receives the
+ * measured [topBar] height so it can insert a leading Spacer instead of applying
+ * top layout padding.
+ */
+@Composable
+fun BlurScreenScaffold(
+    blurConfig: BlurConfig,
+    modifier: Modifier = Modifier,
+    containerColor: Color,
+    topBar: @Composable (() -> Unit)? = null,
+    content: @Composable (topBarHeight: Dp) -> Unit,
+) {
+    val density = LocalDensity.current
+    BlurHost(blurConfig = blurConfig) {
+        SubcomposeLayout(
+            modifier = modifier.fillMaxSize().background(containerColor)
+        ) { constraints ->
+            val barPlaceables = if (topBar != null) {
+                subcompose("abk-top-bar", topBar)
+                    .map { it.measure(constraints.copy(minHeight = 0)) }
+            } else {
+                emptyList()
+            }
+            val barHeightPx = barPlaceables.maxOfOrNull { it.height } ?: 0
+            val contentPlaceable = subcompose("abk-body") {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .blurSourceBody()
+                        .windowInsetsPadding(
+                            WindowInsets.safeDrawing.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                            )
+                        )
+                ) {
+                    content(with(density) { barHeightPx.toDp() })
+                }
+            }.first().measure(constraints)
+            layout(constraints.maxWidth, constraints.maxHeight) {
+                contentPlaceable.place(0, 0)
+                barPlaceables.forEach { it.place(0, 0) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
@@ -5,50 +5,22 @@ import androidx.compose.runtime.compositionLocalOf
 import top.yukonga.miuix.kmp.blur.LayerBackdrop
 import top.yukonga.miuix.kmp.shader.isRuntimeShaderSupported
 
-/**
- * Composition local that exposes the active [LayerBackdrop] to blur consumers.
- *
- * Content that should be captured as the blur source attaches [Modifier.blurSource]
- * (wraps [top.yukonga.miuix.kmp.blur.layerBackdrop]); bars that should show a
- * frosted-glass effect attach [Modifier.blurEffect] (wraps
- * [top.yukonga.miuix.kmp.blur.textureBlur]). Both no-op when no backdrop is provided
- * (which is always the case below API 33, see [isBlurCapableDevice]).
- */
+/** Exposes active [LayerBackdrop] to blur consumers. */
 val LocalBlurState = compositionLocalOf<LayerBackdrop?> { null }
 
-/**
- * Immutable snapshot of the blur feature's preferences for one screen.
- *
- * Collapses the values every [BlurScreenScaffold] call site needs into a single
- * argument, so future toggles touch one place instead of every screen.
- */
+/** Immutable snapshot of blur preferences. */
 data class BlurConfig(
     val blurEnabled: Boolean,
     val backgroundExpEnabled: Boolean,
     val backgroundUri: String?,
     val backgroundImageEnabled: Boolean,
 ) {
-    /** True when a custom background should be drawn into the blur source. */
     val wantsBackgroundPainter: Boolean
         get() = blurEnabled && backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
 }
 
-/**
- * Whether the device can actually render the miuix frosted-glass path.
- *
- * miuix's `textureBlur` runs on AGSL runtime shaders, which exist from API 33
- * onward. This is the single gate both backdrop creation ([BlurBackdrop]) and
- * [isBlurActive] use, so the two cannot drift apart.
- */
 internal fun isBlurCapableDevice(): Boolean = isRuntimeShaderSupported()
 
-/**
- * Whether frosted-glass will actually render for [enableBlur] in the current composition.
- *
- * The miuix render path needs the user toggle, an active backdrop (which itself is
- * only created when the device is blur-capable), and [isBlurCapableDevice]. Callers
- * must use this to decide between a transparent bar and the opaque fallback surface.
- */
 @Composable
 fun isBlurActive(enableBlur: Boolean): Boolean =
     enableBlur && LocalBlurState.current != null && isBlurCapableDevice()

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
@@ -17,12 +17,12 @@ data class BlurConfig(
 ) {
     /**
      * Whether the software StackBlur card path should render the custom background into
-     * cards. Deliberately independent of [blurEnabled]: the software path needs no
-     * runtime shaders, so it must be reachable on API 26-32 where the AGSL bar blur
-     * (and its settings toggle) does not exist.
+     * cards. The master [blurEnabled] switch stays the overall on/off for every blur
+     * surface (AGSL bars on API 33+, software card blur on every API), while
+     * [backgroundExpEnabled] opts the card path into using the custom background.
      */
     val wantsBackgroundPainter: Boolean
-        get() = backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+        get() = blurEnabled && backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
 }
 
 internal fun isBlurCapableDevice(): Boolean = isRuntimeShaderSupported()

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
@@ -1,0 +1,54 @@
+package com.abk.kernel.ui.blur
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import top.yukonga.miuix.kmp.blur.LayerBackdrop
+import top.yukonga.miuix.kmp.shader.isRuntimeShaderSupported
+
+/**
+ * Composition local that exposes the active [LayerBackdrop] to blur consumers.
+ *
+ * Content that should be captured as the blur source attaches [Modifier.blurSource]
+ * (wraps [top.yukonga.miuix.kmp.blur.layerBackdrop]); bars that should show a
+ * frosted-glass effect attach [Modifier.blurEffect] (wraps
+ * [top.yukonga.miuix.kmp.blur.textureBlur]). Both no-op when no backdrop is provided
+ * (which is always the case below API 33, see [isBlurCapableDevice]).
+ */
+val LocalBlurState = compositionLocalOf<LayerBackdrop?> { null }
+
+/**
+ * Immutable snapshot of the blur feature's preferences for one screen.
+ *
+ * Collapses the values every [BlurScreenScaffold] call site needs into a single
+ * argument, so future toggles touch one place instead of every screen.
+ */
+data class BlurConfig(
+    val blurEnabled: Boolean,
+    val backgroundExpEnabled: Boolean,
+    val backgroundUri: String?,
+    val backgroundImageEnabled: Boolean,
+) {
+    /** True when a custom background should be drawn into the blur source. */
+    val wantsBackgroundPainter: Boolean
+        get() = blurEnabled && backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+}
+
+/**
+ * Whether the device can actually render the miuix frosted-glass path.
+ *
+ * miuix's `textureBlur` runs on AGSL runtime shaders, which exist from API 33
+ * onward. This is the single gate both backdrop creation ([BlurBackdrop]) and
+ * [isBlurActive] use, so the two cannot drift apart.
+ */
+internal fun isBlurCapableDevice(): Boolean = isRuntimeShaderSupported()
+
+/**
+ * Whether frosted-glass will actually render for [enableBlur] in the current composition.
+ *
+ * The miuix render path needs the user toggle, an active backdrop (which itself is
+ * only created when the device is blur-capable), and [isBlurCapableDevice]. Callers
+ * must use this to decide between a transparent bar and the opaque fallback surface.
+ */
+@Composable
+fun isBlurActive(enableBlur: Boolean): Boolean =
+    enableBlur && LocalBlurState.current != null && isBlurCapableDevice()

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurState.kt
@@ -15,8 +15,14 @@ data class BlurConfig(
     val backgroundUri: String?,
     val backgroundImageEnabled: Boolean,
 ) {
+    /**
+     * Whether the software StackBlur card path should render the custom background into
+     * cards. Deliberately independent of [blurEnabled]: the software path needs no
+     * runtime shaders, so it must be reachable on API 26-32 where the AGSL bar blur
+     * (and its settings toggle) does not exist.
+     */
     val wantsBackgroundPainter: Boolean
-        get() = blurEnabled && backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+        get() = backgroundExpEnabled && backgroundImageEnabled && !backgroundUri.isNullOrBlank()
 }
 
 internal fun isBlurCapableDevice(): Boolean = isRuntimeShaderSupported()

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -5,6 +5,7 @@ import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
+import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
@@ -30,6 +31,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import coil.compose.AsyncImagePainter
 import coil.imageLoader
 import coil.request.ImageRequest
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
@@ -163,8 +165,19 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
+    // Reuse the bitmap the enclosing AppBackgroundHost already decoded for the shared
+    // wallpaper painter instead of issuing a second Coil decode. This keeps the wallpaper
+    // to a single decode and stops the blur pass from competing with the wallpaper decode
+    // on cold start (the black-flash window on low-end devices). The painter's `state` is a
+    // Compose snapshot state, so reading it here re-runs the effect once the decode lands.
+    val sharedPainter = LocalBlurredBackgroundPainter.current as? AsyncImagePainter
+    val sourceBitmap = (sharedPainter?.state as? AsyncImagePainter.State.Success)
+        ?.result
+        ?.drawable
+        ?.let { it as? BitmapDrawable }
+        ?.bitmap
     // Re-blur only when the viewport grows past the cached blur; shrink (IME) is covered.
-    LaunchedEffect(uri, enabled, widthPx, heightPx) {
+    LaunchedEffect(uri, enabled, widthPx, heightPx, sourceBitmap) {
         val previousUri = cachedBlurredCardUri
         if (previousUri != null && previousUri != uri) {
             cachedBlurredCardBackground = null
@@ -180,10 +193,19 @@ fun rememberBlurredCardBackground(
         }
         val loaded = withContext(Dispatchers.Default) {
             loadBlurCache(context, uri, targetWidth, targetHeight)
-                ?: run {
+                ?: sourceBitmap?.let { source ->
                     try {
-                        val loader = context.imageLoader
-                        val result = loader.execute(
+                        blurSourceToBackground(source, targetWidth, targetHeight)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        null
+                    }
+                }
+                ?: if (sharedPainter == null) {
+                    // Defensive fallback: no shared painter to reuse, decode independently.
+                    try {
+                        val result = context.imageLoader.execute(
                             ImageRequest.Builder(context)
                                 .data(uri)
                                 .size(
@@ -193,20 +215,17 @@ fun rememberBlurredCardBackground(
                                 .allowHardware(false)
                                 .build()
                         )
-                        val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
-                            ?: return@withContext null
-                        blurCoverBitmap(source, AbkCardBlurRadius, targetWidth, targetHeight)
-                            ?.let { blurredBitmap ->
-                                BlurredCardBackground(
-                                    image = blurredBitmap.asImageBitmap(),
-                                    viewportSize = IntSize(targetWidth, targetHeight),
-                                )
-                            }
+                        (result.drawable as? BitmapDrawable)?.bitmap
+                            ?.let { blurSourceToBackground(it, targetWidth, targetHeight) }
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
                         null
                     }
+                } else {
+                    // Shared painter exists but its bitmap has not landed yet; the effect
+                    // re-runs when the painter's state changes.
+                    null
                 }
         }
         if (loaded != null) {
@@ -363,6 +382,15 @@ private fun LayoutCoordinates.localBoundsInWindowNow(): Rect? {
         bottom = points.maxOf { it.y },
     )
 }
+
+/** Downsamples + blurs [source] into a viewport-aligned [BlurredCardBackground]. */
+private fun blurSourceToBackground(source: Bitmap, viewportW: Int, viewportH: Int): BlurredCardBackground? =
+    blurCoverBitmap(source, AbkCardBlurRadius, viewportW, viewportH)?.let { blurred ->
+        BlurredCardBackground(
+            image = blurred.asImageBitmap(),
+            viewportSize = IntSize(viewportW, viewportH),
+        )
+    }
 
 private fun blurCoverBitmap(source: Bitmap, radiusPx: Float, viewportW: Int, viewportH: Int): Bitmap? {
     if (source.isRecycled || viewportW <= 0 || viewportH <= 0) return null

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
@@ -104,6 +105,51 @@ private fun pruneBlurCache(context: android.content.Context) {
     }
 }
 
+/**
+ * Decodes a small, downsampled copy of the custom background directly from [uri]
+ * (local file or content stream). Used when the on-disk blur cache misses but the
+ * shared wallpaper painter's bitmap has not landed yet, so the card backdrop does not
+ * wait on the full-size wallpaper decode after a cold start.
+ */
+private fun decodeBlurSource(
+    context: android.content.Context,
+    uri: String,
+    viewportW: Int,
+    viewportH: Int,
+): Bitmap? = runCatching {
+    val parsed = Uri.parse(uri)
+    val targetW = (viewportW / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+    val targetH = (viewportH / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+    val file = if (parsed.scheme == "file") parsed.path?.let { File(it) } else null
+
+    // First pass: decode bounds only to pick a power-of-two sample size.
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    if (file != null) {
+        BitmapFactory.decodeFile(file.absolutePath, bounds)
+    } else {
+        context.contentResolver.openInputStream(parsed)?.use {
+            BitmapFactory.decodeStream(it, null, bounds)
+        }
+    }
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@runCatching null
+
+    var sample = 1
+    while (bounds.outWidth / (sample * 2) >= targetW && bounds.outHeight / (sample * 2) >= targetH) {
+        sample *= 2
+    }
+    val opts = BitmapFactory.Options().apply {
+        inSampleSize = sample
+        inPreferredConfig = Bitmap.Config.ARGB_8888
+    }
+    if (file != null) {
+        BitmapFactory.decodeFile(file.absolutePath, opts)
+    } else {
+        context.contentResolver.openInputStream(parsed)?.use {
+            BitmapFactory.decodeStream(it, null, opts)
+        }
+    }
+}.getOrNull()
+
 /** Loads a previously cached pre-blurred wallpaper that matches the viewport, if any. */
 private fun loadBlurCache(
     context: android.content.Context,
@@ -183,7 +229,12 @@ fun rememberBlurredCardBackground(
             cachedBlurredCardBackground = null
         }
         cachedBlurredCardUri = uri
-        delay(AbkCardBlurLoadDebounceMs)
+        // Debounce only viewport-change re-runs. The first load for a URI — and the
+        // re-run once the wallpaper decode lands after a cold start — must not wait,
+        // so the frosted backdrop appears as soon as possible.
+        if (cachedBlurredCardBackground != null) {
+            delay(AbkCardBlurLoadDebounceMs)
+        }
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
         val targetHeight = heightPx
@@ -202,6 +253,16 @@ fun rememberBlurredCardBackground(
                         null
                     }
                 }
+                ?: decodeBlurSource(context, uri, targetWidth, targetHeight)
+                    ?.let { source ->
+                        try {
+                            blurSourceToBackground(source, targetWidth, targetHeight)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
                 ?: if (sharedPainter == null) {
                     // Defensive fallback: no shared painter to reuse, decode independently.
                     try {

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import coil.imageLoader
 import coil.request.ImageRequest
+import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.ui.theme.uiSurfaceColor
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -51,6 +53,9 @@ val LocalBlurBackgroundAnchor = compositionLocalOf<LayoutCoordinates?> { null }
 internal const val AbkCardBlurRadius = 45f
 private const val AbkCardBlurDownsample = 4
 
+/** Debounce before re-running the full decode + StackBlur pass on viewport changes. */
+private const val AbkCardBlurLoadDebounceMs = 200L
+
 @Composable
 fun rememberBlurredCardBackground(
     uri: String?,
@@ -63,8 +68,16 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
-    var bitmap by remember(uri, widthPx, heightPx) { mutableStateOf<BlurredCardBackground?>(null) }
-    LaunchedEffect(uri, widthPx, heightPx) {
+    var bitmap by remember(uri, enabled) { mutableStateOf<BlurredCardBackground?>(null) }
+    // Restarting this effect on every size change cancels the in-flight debounce, so a
+    // rotation / split-screen resize only runs the final decode + StackBlur pass once the
+    // viewport settles (previously it re-ran for every intermediate size).
+    LaunchedEffect(uri, enabled, widthPx, heightPx) {
+        bitmap = null
+        delay(AbkCardBlurLoadDebounceMs)
+        if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
+        val targetWidth = widthPx
+        val targetHeight = heightPx
         bitmap = withContext(Dispatchers.Default) {
             runCatching {
                 val loader = context.imageLoader
@@ -72,20 +85,21 @@ fun rememberBlurredCardBackground(
                     ImageRequest.Builder(context)
                         .data(uri)
                         .size(
-                            (widthPx / AbkCardBlurDownsample).coerceAtLeast(1),
-                            (heightPx / AbkCardBlurDownsample).coerceAtLeast(1),
+                            (targetWidth / AbkCardBlurDownsample).coerceAtLeast(1),
+                            (targetHeight / AbkCardBlurDownsample).coerceAtLeast(1),
                         )
                         .allowHardware(false)
                         .build()
                 )
                 val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
                     ?: return@withContext null
-                blurCoverBitmap(source, AbkCardBlurRadius, widthPx, heightPx)?.let { blurredBitmap ->
-                    BlurredCardBackground(
-                        image = blurredBitmap.asImageBitmap(),
-                        viewportSize = IntSize(widthPx, heightPx),
-                    )
-                }
+                blurCoverBitmap(source, AbkCardBlurRadius, targetWidth, targetHeight)
+                    ?.let { blurredBitmap ->
+                        BlurredCardBackground(
+                            image = blurredBitmap.asImageBitmap(),
+                            viewportSize = IntSize(targetWidth, targetHeight),
+                        )
+                    }
             }.getOrNull()
         }
     }
@@ -93,8 +107,17 @@ fun rememberBlurredCardBackground(
 }
 
 @Composable
-/** Surface tint used by cards/tiles. */
-fun blurredCardSurfaceColor(color: Color): Color = uiSurfaceColor(color)
+/**
+ * Surface tint used by cards/tiles. When a pre-blurred custom background is present the
+ * tint stays translucent (capped by [AbkBlurTintAlpha]) so the frosted backdrop shows
+ * through even at the default opaque surface alpha; otherwise it follows the regular
+ * [uiSurfaceColor] opacity rule.
+ */
+fun blurredCardSurfaceColor(color: Color): Color {
+    if (LocalBlurredCardBackground.current == null) return uiSurfaceColor(color)
+    val alpha = (LocalUiSurfaceAlpha.current * AbkBlurTintAlpha).coerceIn(0f, 1f)
+    return if (alpha >= 0.995f) color else color.copy(alpha = color.alpha * alpha)
+}
 
 @Composable
 /** Draws shared blurred custom background underneath this surface. */
@@ -184,19 +207,14 @@ private fun LayoutCoordinates.boundsInBackgroundNow(
 private fun LayoutCoordinates.boundsInCoordinatesNow(
     targetCoordinates: LayoutCoordinates,
 ): Rect? {
-    fun localToTarget(point: Offset): Offset {
-        val screenPoint = localToScreen(point)
-        if (!screenPoint.x.isFinite() || !screenPoint.y.isFinite()) return Offset.Unspecified
-        return targetCoordinates.screenToLocal(screenPoint)
-    }
-
     val width = size.width.toFloat()
     val height = size.height.toFloat()
+    // Single coordinate-space hop (no screen round-trip) per corner.
     val points = listOf(
-        localToTarget(Offset.Zero),
-        localToTarget(Offset(width, 0f)),
-        localToTarget(Offset(0f, height)),
-        localToTarget(Offset(width, height)),
+        targetCoordinates.localPositionOf(this, Offset.Zero),
+        targetCoordinates.localPositionOf(this, Offset(width, 0f)),
+        targetCoordinates.localPositionOf(this, Offset(0f, height)),
+        targetCoordinates.localPositionOf(this, Offset(width, height)),
     )
     if (points.any { !it.x.isFinite() || !it.y.isFinite() }) return null
     return Rect(

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -59,7 +59,9 @@ fun rememberBlurredCardBackground(
     val viewportSize = LocalBlurBackgroundAnchor.current?.size
     val widthPx = viewportSize?.width ?: 0
     val heightPx = viewportSize?.height ?: 0
-    if (!enabled || uri.isNullOrBlank() || !isBlurCapableDevice() || widthPx <= 0 || heightPx <= 0) {
+    if (!enabled || uri.isNullOrBlank() || widthPx <= 0 || heightPx <= 0) {
+        return null
+    }
         return null
     }
     val context = LocalContext.current

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -32,6 +32,7 @@ import coil.imageLoader
 import coil.request.ImageRequest
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.ui.theme.uiSurfaceColor
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -79,7 +80,7 @@ fun rememberBlurredCardBackground(
         val targetWidth = widthPx
         val targetHeight = heightPx
         bitmap = withContext(Dispatchers.Default) {
-            runCatching {
+            try {
                 val loader = context.imageLoader
                 val result = loader.execute(
                     ImageRequest.Builder(context)
@@ -100,7 +101,15 @@ fun rememberBlurredCardBackground(
                             viewportSize = IntSize(targetWidth, targetHeight),
                         )
                     }
-            }.getOrNull()
+            } catch (e: CancellationException) {
+                // Restart on a viewport change cancels this pass mid-StackBlur; propagate
+                // so the cancelled effect cannot later overwrite the newer effect's result.
+                throw e
+            } catch (e: Exception) {
+                // Coil/StackBlur failure: fall back to the opaque surface tint. Errors
+                // (e.g. OutOfMemoryError) are deliberately not caught here.
+                null
+            }
         }
     }
     return bitmap

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -69,7 +69,14 @@ fun rememberBlurredCardBackground(
             runCatching {
                 val loader = context.imageLoader
                 val result = loader.execute(
-                    ImageRequest.Builder(context).data(uri).allowHardware(false).build()
+                    ImageRequest.Builder(context)
+                        .data(uri)
+                        .size(
+                            (widthPx / AbkCardBlurDownsample).coerceAtLeast(1),
+                            (heightPx / AbkCardBlurDownsample).coerceAtLeast(1),
+                        )
+                        .allowHardware(false)
+                        .build()
                 )
                 val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
                     ?: return@withContext null

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -74,12 +74,14 @@ fun rememberBlurredCardBackground(
     // rotation / split-screen resize only runs the final decode + StackBlur pass once the
     // viewport settles (previously it re-ran for every intermediate size).
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
-        bitmap = null
         delay(AbkCardBlurLoadDebounceMs)
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
         val targetHeight = heightPx
-        bitmap = withContext(Dispatchers.Default) {
+        // Swap the replacement in only after it is ready, so transient viewport changes
+        // (e.g. the soft keyboard resizing the window) keep the previous frosted backdrop
+        // instead of flashing cards to an opaque surface while it re-blurs.
+        val loaded = withContext(Dispatchers.Default) {
             try {
                 val loader = context.imageLoader
                 val result = loader.execute(
@@ -110,6 +112,9 @@ fun rememberBlurredCardBackground(
                 // (e.g. OutOfMemoryError) are deliberately not caught here.
                 null
             }
+        }
+        if (loaded != null) {
+            bitmap = loaded
         }
     }
     return bitmap

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -1,6 +1,7 @@
 package com.abk.kernel.ui.blur
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
@@ -20,6 +21,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.Shape
@@ -32,6 +34,8 @@ import coil.imageLoader
 import coil.request.ImageRequest
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.ui.theme.uiSurfaceColor
+import java.io.File
+import java.io.FileOutputStream
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -57,6 +61,59 @@ private const val AbkCardBlurDownsample = 4
 /** Debounce before re-running the full decode + StackBlur pass on viewport changes. */
 private const val AbkCardBlurLoadDebounceMs = 200L
 
+/**
+ * Global pre-blurred card background cache. Keeping it at module scope (not in a
+ * Composable remember) means recompositions and transient viewport changes (e.g. the
+ * soft keyboard resizing the window) keep the previous frosted backdrop instead of
+ * re-decoding + re-blurring the wallpaper from scratch. Keyed by the custom background
+ * URI; the bitmap is sized to the viewport at load time.
+ */
+private var cachedBlurredCardBackground by mutableStateOf<BlurredCardBackground?>(null)
+private var cachedBlurredCardUri by mutableStateOf<String?>(null)
+
+private fun blurCacheFile(context: android.content.Context): File =
+    File(context.filesDir, "abk_blurred_custom_background.jpg")
+
+/** Loads a previously cached pre-blurred wallpaper that matches the viewport, if any. */
+private fun loadBlurCache(
+    context: android.content.Context,
+    viewportW: Int,
+    viewportH: Int,
+): BlurredCardBackground? {
+    val file = blurCacheFile(context)
+    if (!file.exists()) return null
+    return runCatching {
+        val decoded = BitmapFactory.decodeFile(file.absolutePath) ?: return@runCatching null
+        val expectedW = (viewportW / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+        val expectedH = (viewportH / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+        if (decoded.width != expectedW || decoded.height != expectedH) {
+            decoded.recycle()
+            return@runCatching null
+        }
+        BlurredCardBackground(
+            image = decoded.asImageBitmap(),
+            viewportSize = IntSize(viewportW, viewportH),
+        )
+    }.getOrNull()
+}
+
+/** Persists the pre-blurred wallpaper so the next launch / matching viewport reuses it. */
+private fun saveBlurCache(context: android.content.Context, background: BlurredCardBackground) {
+    runCatching {
+        val file = blurCacheFile(context)
+        file.parentFile?.mkdirs()
+        val bitmap = background.image.asAndroidBitmap()
+        val temp = File(file.parentFile, "${file.name}.tmp")
+        FileOutputStream(temp).use { it ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it)
+        }
+        if (!temp.renameTo(file)) {
+            temp.copyTo(file, overwrite = true)
+            temp.delete()
+        }
+    }
+}
+
 @Composable
 fun rememberBlurredCardBackground(
     uri: String?,
@@ -69,55 +126,71 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
-    var bitmap by remember(uri, enabled) { mutableStateOf<BlurredCardBackground?>(null) }
     // Restarting this effect on every size change cancels the in-flight debounce, so a
     // rotation / split-screen resize only runs the final decode + StackBlur pass once the
-    // viewport settles (previously it re-ran for every intermediate size).
+    // viewport settles. The result goes into the module-level cache, so transient changes
+    // (soft keyboard resizing the window) keep showing the previous frosted backdrop until
+    // the new one is ready, and matching viewports are restored from disk instead of
+    // re-blurring from scratch.
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
+        // Wallpaper changed: drop the stale memory + disk blur for the old image.
+        if (cachedBlurredCardUri != uri) {
+            cachedBlurredCardBackground = null
+            cachedBlurredCardUri = uri
+            blurCacheFile(context).delete()
+        }
         delay(AbkCardBlurLoadDebounceMs)
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
         val targetHeight = heightPx
-        // Swap the replacement in only after it is ready, so transient viewport changes
-        // (e.g. the soft keyboard resizing the window) keep the previous frosted backdrop
-        // instead of flashing cards to an opaque surface while it re-blurs.
+        // Already have a blur sized for this viewport (e.g. re-entering a known size).
+        if (cachedBlurredCardBackground?.viewportSize == IntSize(targetWidth, targetHeight)) {
+            return@LaunchedEffect
+        }
         val loaded = withContext(Dispatchers.Default) {
-            try {
-                val loader = context.imageLoader
-                val result = loader.execute(
-                    ImageRequest.Builder(context)
-                        .data(uri)
-                        .size(
-                            (targetWidth / AbkCardBlurDownsample).coerceAtLeast(1),
-                            (targetHeight / AbkCardBlurDownsample).coerceAtLeast(1),
+            loadBlurCache(context, targetWidth, targetHeight)
+                ?: run {
+                    try {
+                        val loader = context.imageLoader
+                        val result = loader.execute(
+                            ImageRequest.Builder(context)
+                                .data(uri)
+                                .size(
+                                    (targetWidth / AbkCardBlurDownsample).coerceAtLeast(1),
+                                    (targetHeight / AbkCardBlurDownsample).coerceAtLeast(1),
+                                )
+                                .allowHardware(false)
+                                .build()
                         )
-                        .allowHardware(false)
-                        .build()
-                )
-                val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
-                    ?: return@withContext null
-                blurCoverBitmap(source, AbkCardBlurRadius, targetWidth, targetHeight)
-                    ?.let { blurredBitmap ->
-                        BlurredCardBackground(
-                            image = blurredBitmap.asImageBitmap(),
-                            viewportSize = IntSize(targetWidth, targetHeight),
-                        )
+                        val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
+                            ?: return@withContext null
+                        blurCoverBitmap(source, AbkCardBlurRadius, targetWidth, targetHeight)
+                            ?.let { blurredBitmap ->
+                                BlurredCardBackground(
+                                    image = blurredBitmap.asImageBitmap(),
+                                    viewportSize = IntSize(targetWidth, targetHeight),
+                                )
+                            }
+                    } catch (e: CancellationException) {
+                        // Restart on a viewport change cancels this pass mid-StackBlur; propagate
+                        // so the cancelled effect cannot later overwrite the newer effect's result.
+                        throw e
+                    } catch (e: Exception) {
+                        // Coil/StackBlur failure: fall back to the opaque surface tint. Errors
+                        // (e.g. OutOfMemoryError) are deliberately not caught here.
+                        null
                     }
-            } catch (e: CancellationException) {
-                // Restart on a viewport change cancels this pass mid-StackBlur; propagate
-                // so the cancelled effect cannot later overwrite the newer effect's result.
-                throw e
-            } catch (e: Exception) {
-                // Coil/StackBlur failure: fall back to the opaque surface tint. Errors
-                // (e.g. OutOfMemoryError) are deliberately not caught here.
-                null
-            }
+                }
         }
         if (loaded != null) {
-            bitmap = loaded
+            cachedBlurredCardBackground = loaded
+            saveBlurCache(context, loaded)
         }
     }
-    return bitmap
+    // Only hand out the blurred wallpaper for the current custom background; viewport
+    // mismatches are kept (previous size) until the LaunchedEffect replaces it, so the
+    // frosted cards never flash to an opaque surface on a transient resize.
+    return cachedBlurredCardBackground?.takeIf { cachedBlurredCardUri == uri }
 }
 
 @Composable

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -36,6 +36,7 @@ import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 import com.abk.kernel.ui.theme.uiSurfaceColor
 import java.io.File
 import java.io.FileOutputStream
+import java.security.MessageDigest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -87,13 +88,35 @@ private const val AbkCardBlurLoadDebounceMs = 200L
 private var cachedBlurredCardBackground by mutableStateOf<BlurredCardBackground?>(null)
 private var cachedBlurredCardUri by mutableStateOf<String?>(null)
 
+/** Bump when the blur parameters change so old cache files are not reused. */
+private const val AbkBlurCacheVersion = 1
+/** Upper bound on on-disk cache entries; older ones are pruned on save. */
+private const val AbkBlurCacheMaxFiles = 4
+
+/** Collision-resistant cache key: SHA-256 of the URI, not a 32-bit hashCode(). */
+private fun blurCacheKey(uri: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(uri.toByteArray(Charsets.UTF_8))
+    return digest.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+}
+
 private fun blurCacheFile(context: android.content.Context, uri: String): File {
-    // Key the cache file by the background URI. String.hashCode() is spec-defined and
-    // stable across processes, so a previous launch's blur is only reused for the same
-    // wallpaper. Without this, a single-slot file would serve a stale wallpaper's blur
-    // after the background changes across launches.
-    val key = Integer.toHexString(uri.hashCode())
+    // Version + blur radius + downsample in the name so a future algorithm change cannot
+    // silently reuse a cache produced with different parameters, and two distinct URIs
+    // cannot collide into the same file.
+    val key = "v${AbkBlurCacheVersion}_r${AbkCardBlurRadius.toInt()}_d${AbkCardBlurDownsample}_${blurCacheKey(uri)}"
     return File(context.filesDir, "abk_blurred_custom_background_$key.jpg")
+}
+
+/** Deletes the oldest cache entries beyond [AbkBlurCacheMaxFiles], newest first. */
+private fun pruneBlurCache(context: android.content.Context) {
+    runCatching {
+        val prefix = "abk_blurred_custom_background_"
+        context.filesDir.listFiles { file ->
+            file.name.startsWith(prefix) && file.name.endsWith(".jpg")
+        }?.sortedByDescending { it.lastModified() }
+            ?.drop(AbkBlurCacheMaxFiles)
+            ?.forEach { it.delete() }
+    }
 }
 
 /** Loads a previously cached pre-blurred wallpaper that matches the viewport, if any. */
@@ -160,13 +183,13 @@ fun rememberBlurredCardBackground(
     // the new one is ready, and matching viewports are restored from disk instead of
     // re-blurring from scratch.
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
-        // Wallpaper changed: drop the stale in-memory blur for the old image and clean up
-        // its on-disk cache. On a fresh process cachedBlurredCardUri is null, so the
+        // Wallpaper changed: drop the stale in-memory blur for the old image, but keep its
+        // on-disk cache so switching back reuses it (bounded by pruneBlurCache on save,
+        // not deleted per change). On a fresh process cachedBlurredCardUri is null, so the
         // current wallpaper's disk cache is left intact for loadBlurCache below to reuse.
         val previousUri = cachedBlurredCardUri
         if (previousUri != null && previousUri != uri) {
             cachedBlurredCardBackground = null
-            blurCacheFile(context, previousUri).delete()
         }
         cachedBlurredCardUri = uri
         delay(AbkCardBlurLoadDebounceMs)
@@ -217,6 +240,7 @@ fun rememberBlurredCardBackground(
             // JPEG compress + disk write; keep off the main thread (StrictMode / jank).
             withContext(Dispatchers.IO) {
                 saveBlurCache(context, uri, loaded)
+                pruneBlurCache(context)
             }
         }
     }

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -79,16 +79,23 @@ private const val AbkCardBlurLoadDebounceMs = 200L
 private var cachedBlurredCardBackground by mutableStateOf<BlurredCardBackground?>(null)
 private var cachedBlurredCardUri by mutableStateOf<String?>(null)
 
-private fun blurCacheFile(context: android.content.Context): File =
-    File(context.filesDir, "abk_blurred_custom_background.jpg")
+private fun blurCacheFile(context: android.content.Context, uri: String): File {
+    // Key the cache file by the background URI. String.hashCode() is spec-defined and
+    // stable across processes, so a previous launch's blur is only reused for the same
+    // wallpaper. Without this, a single-slot file would serve a stale wallpaper's blur
+    // after the background changes across launches.
+    val key = Integer.toHexString(uri.hashCode())
+    return File(context.filesDir, "abk_blurred_custom_background_$key.jpg")
+}
 
 /** Loads a previously cached pre-blurred wallpaper that matches the viewport, if any. */
 private fun loadBlurCache(
     context: android.content.Context,
+    uri: String,
     viewportW: Int,
     viewportH: Int,
 ): BlurredCardBackground? {
-    val file = blurCacheFile(context)
+    val file = blurCacheFile(context, uri)
     if (!file.exists()) return null
     return runCatching {
         val decoded = BitmapFactory.decodeFile(file.absolutePath) ?: return@runCatching null
@@ -106,9 +113,13 @@ private fun loadBlurCache(
 }
 
 /** Persists the pre-blurred wallpaper so the next launch / matching viewport reuses it. */
-private fun saveBlurCache(context: android.content.Context, background: BlurredCardBackground) {
+private fun saveBlurCache(
+    context: android.content.Context,
+    uri: String,
+    background: BlurredCardBackground,
+) {
     runCatching {
-        val file = blurCacheFile(context)
+        val file = blurCacheFile(context, uri)
         file.parentFile?.mkdirs()
         val bitmap = background.image.asAndroidBitmap()
         val temp = File(file.parentFile, "${file.name}.tmp")
@@ -141,16 +152,15 @@ fun rememberBlurredCardBackground(
     // the new one is ready, and matching viewports are restored from disk instead of
     // re-blurring from scratch.
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
-        // Wallpaper changed: drop the stale memory + disk blur for the old image.
-if (cachedBlurredCardUri != null && cachedBlurredCardUri != uri) {
-    cachedBlurredCardBackground = null
-    blurCacheFile(context).delete()
-}
-cachedBlurredCardUri = uri
+        // Wallpaper changed: drop the stale in-memory blur for the old image and clean up
+        // its on-disk cache. On a fresh process cachedBlurredCardUri is null, so the
+        // current wallpaper's disk cache is left intact for loadBlurCache below to reuse.
+        val previousUri = cachedBlurredCardUri
+        if (previousUri != null && previousUri != uri) {
             cachedBlurredCardBackground = null
-            cachedBlurredCardUri = uri
-            blurCacheFile(context).delete()
+            blurCacheFile(context, previousUri).delete()
         }
+        cachedBlurredCardUri = uri
         delay(AbkCardBlurLoadDebounceMs)
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
@@ -160,7 +170,7 @@ cachedBlurredCardUri = uri
             return@LaunchedEffect
         }
         val loaded = withContext(Dispatchers.Default) {
-            loadBlurCache(context, targetWidth, targetHeight)
+            loadBlurCache(context, uri, targetWidth, targetHeight)
                 ?: run {
                     try {
                         val loader = context.imageLoader
@@ -196,7 +206,7 @@ cachedBlurredCardUri = uri
         }
         if (loaded != null) {
             cachedBlurredCardBackground = loaded
-            saveBlurCache(context, loaded)
+            saveBlurCache(context, uri, loaded)
         }
     }
     // Only hand out the blurred wallpaper for the current custom background; viewport

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -56,6 +56,14 @@ val LocalBlurredCardBackground = compositionLocalOf<BlurredCardBackground?> { nu
 val LocalBlurBackgroundAnchor = compositionLocalOf<LayoutCoordinates?> { null }
 
 /**
+ * Snapshot-observable size of the shared background anchor. Reading this in composition
+ * resubscribes on every real viewport resize, unlike [LocalBlurBackgroundAnchor]'s `size`
+ * (which is not observable), so the pre-blurred card backdrop re-blurs when the window
+ * actually resizes (split-screen, freeform, IME on adjustResize devices).
+ */
+val LocalBlurBackgroundSize = compositionLocalOf { IntSize.Zero }
+
+/**
  * Whether the render-custom-background-into-blur feature is enabled. Unlike
  * [LocalBlurredCardBackground] this is a synchronous signal that does not wait for the
  * pre-blurred bitmap to load, so surfaces can stay translucent from the first frame and
@@ -138,9 +146,9 @@ fun rememberBlurredCardBackground(
     uri: String?,
     enabled: Boolean,
 ): BlurredCardBackground? {
-    val viewportSize = LocalBlurBackgroundAnchor.current?.size
-    val widthPx = viewportSize?.width ?: 0
-    val heightPx = viewportSize?.height ?: 0
+    val viewportSize = LocalBlurBackgroundSize.current
+    val widthPx = viewportSize.width
+    val heightPx = viewportSize.height
     if (!enabled || uri.isNullOrBlank() || widthPx <= 0 || heightPx <= 0) {
         return null
     }
@@ -206,7 +214,10 @@ fun rememberBlurredCardBackground(
         }
         if (loaded != null) {
             cachedBlurredCardBackground = loaded
-            saveBlurCache(context, uri, loaded)
+            // JPEG compress + disk write; keep off the main thread (StrictMode / jank).
+            withContext(Dispatchers.IO) {
+                saveBlurCache(context, uri, loaded)
+            }
         }
     }
     // Only hand out the blurred wallpaper for the current custom background; viewport

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -56,20 +56,10 @@ data class BlurredCardBackground(
 val LocalBlurredCardBackground = compositionLocalOf<BlurredCardBackground?> { null }
 val LocalBlurBackgroundAnchor = compositionLocalOf<LayoutCoordinates?> { null }
 
-/**
- * Snapshot-observable size of the shared background anchor. Reading this in composition
- * resubscribes on every real viewport resize, unlike [LocalBlurBackgroundAnchor]'s `size`
- * (which is not observable), so the pre-blurred card backdrop re-blurs when the window
- * actually resizes (split-screen, freeform, IME on adjustResize devices).
- */
+/** Observable viewport size; [LocalBlurBackgroundAnchor]'s `size` is not observable. */
 val LocalBlurBackgroundSize = compositionLocalOf { IntSize.Zero }
 
-/**
- * Whether the render-custom-background-into-blur feature is enabled. Unlike
- * [LocalBlurredCardBackground] this is a synchronous signal that does not wait for the
- * pre-blurred bitmap to load, so surfaces can stay translucent from the first frame and
- * never flash opaque→translucent when the frosted backdrop arrives.
- */
+/** Synchronous enable signal, so surfaces stay translucent before the bitmap loads. */
 val LocalBlurredCardBackgroundEnabled = compositionLocalOf { false }
 
 internal const val AbkCardBlurRadius = 45f
@@ -78,13 +68,7 @@ private const val AbkCardBlurDownsample = 4
 /** Debounce before re-running the full decode + StackBlur pass on viewport changes. */
 private const val AbkCardBlurLoadDebounceMs = 200L
 
-/**
- * Global pre-blurred card background cache. Keeping it at module scope (not in a
- * Composable remember) means recompositions and transient viewport changes (e.g. the
- * soft keyboard resizing the window) keep the previous frosted backdrop instead of
- * re-decoding + re-blurring the wallpaper from scratch. Keyed by the custom background
- * URI; the bitmap is sized to the viewport at load time.
- */
+/** Module-scope cache so recompositions and transient resizes keep the previous backdrop. */
 private var cachedBlurredCardBackground by mutableStateOf<BlurredCardBackground?>(null)
 private var cachedBlurredCardUri by mutableStateOf<String?>(null)
 
@@ -100,9 +84,6 @@ private fun blurCacheKey(uri: String): String {
 }
 
 private fun blurCacheFile(context: android.content.Context, uri: String): File {
-    // Version + blur radius + downsample in the name so a future algorithm change cannot
-    // silently reuse a cache produced with different parameters, and two distinct URIs
-    // cannot collide into the same file.
     val key = "v${AbkBlurCacheVersion}_r${AbkCardBlurRadius.toInt()}_d${AbkCardBlurDownsample}_${blurCacheKey(uri)}"
     return File(context.filesDir, "abk_blurred_custom_background_$key.jpg")
 }
@@ -113,9 +94,7 @@ private fun pruneBlurCache(context: android.content.Context) {
         val prefix = "abk_blurred_custom_background_"
         val files = context.filesDir.listFiles { file -> file.name.startsWith(prefix) }
             ?: return@runCatching
-        // Temp files from an interrupted save are never valid; drop them outright.
         files.filter { it.name.endsWith(".tmp") }.forEach { it.delete() }
-        // Keep the newest cache entries, newest first.
         files.filter { it.name.endsWith(".jpg") }
             .sortedByDescending { it.lastModified() }
             .drop(AbkBlurCacheMaxFiles)
@@ -135,7 +114,6 @@ private fun loadBlurCache(
     return runCatching {
         val decoded = BitmapFactory.decodeFile(file.absolutePath)
         if (decoded == null) {
-            // Corrupt / truncated cache: drop it so it isn't retried on every launch.
             file.delete()
             return@runCatching null
         }
@@ -185,16 +163,8 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
-    // Re-blur whenever the viewport grows past the cached blur, but not for shrink-only
-    // changes (IME, freeform shorter): the cached bitmap is a uniform downsample of its
-    // recorded viewport, so it covers any smaller-or-equal viewport exactly. Keying on
-    // both dimensions makes a real height growth (freeform taller, fold unfold) restart
-    // the effect, while the coverage check below skips the expensive pass for IME shrink.
+    // Re-blur only when the viewport grows past the cached blur; shrink (IME) is covered.
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
-        // Wallpaper changed: drop the stale in-memory blur for the old image, but keep its
-        // on-disk cache so switching back reuses it (bounded by pruneBlurCache on save,
-        // not deleted per change). On a fresh process cachedBlurredCardUri is null, so the
-        // current wallpaper's disk cache is left intact for loadBlurCache below to reuse.
         val previousUri = cachedBlurredCardUri
         if (previousUri != null && previousUri != uri) {
             cachedBlurredCardBackground = null
@@ -204,8 +174,6 @@ fun rememberBlurredCardBackground(
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
         val targetHeight = heightPx
-        // Skip only while the cached bitmap still covers the new viewport (shrink / IME);
-        // any dimension that grew past the cached viewport needs a fresh blur.
         val cached = cachedBlurredCardBackground
         if (cached != null && cached.viewportSize.width >= targetWidth && cached.viewportSize.height >= targetHeight) {
             return@LaunchedEffect
@@ -235,28 +203,20 @@ fun rememberBlurredCardBackground(
                                 )
                             }
                     } catch (e: CancellationException) {
-                        // Restart on a viewport change cancels this pass mid-StackBlur; propagate
-                        // so the cancelled effect cannot later overwrite the newer effect's result.
                         throw e
                     } catch (e: Exception) {
-                        // Coil/StackBlur failure: fall back to the opaque surface tint. Errors
-                        // (e.g. OutOfMemoryError) are deliberately not caught here.
                         null
                     }
                 }
         }
         if (loaded != null) {
             cachedBlurredCardBackground = loaded
-            // JPEG compress + disk write; keep off the main thread (StrictMode / jank).
             withContext(Dispatchers.IO) {
                 saveBlurCache(context, uri, loaded)
                 pruneBlurCache(context)
             }
         }
     }
-    // Only hand out the blurred wallpaper for the current custom background; viewport
-    // mismatches are kept (previous size) until the LaunchedEffect replaces it, so the
-    // frosted cards never flash to an opaque surface on a transient resize.
     return cachedBlurredCardBackground?.takeIf { cachedBlurredCardUri == uri }
 }
 
@@ -295,10 +255,6 @@ fun Modifier.blurredCardBackground(
         }
         .drawWithContent {
             layoutRevision
-            // Draw the strip only while the cached bitmap covers the current anchor. If
-            // the anchor has grown past the cached viewport (rotation / split-screen /
-            // freeform taller, before the re-blur lands), skip so the stale bitmap is not
-            // stretched across the new bounds.
             if (
                 bitmap.viewportSize.width >= anchorSize.width &&
                 bitmap.viewportSize.height >= anchorSize.height

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -55,6 +55,14 @@ data class BlurredCardBackground(
 val LocalBlurredCardBackground = compositionLocalOf<BlurredCardBackground?> { null }
 val LocalBlurBackgroundAnchor = compositionLocalOf<LayoutCoordinates?> { null }
 
+/**
+ * Whether the render-custom-background-into-blur feature is enabled. Unlike
+ * [LocalBlurredCardBackground] this is a synchronous signal that does not wait for the
+ * pre-blurred bitmap to load, so surfaces can stay translucent from the first frame and
+ * never flash opaque→translucent when the frosted backdrop arrives.
+ */
+val LocalBlurredCardBackgroundEnabled = compositionLocalOf { false }
+
 internal const val AbkCardBlurRadius = 45f
 private const val AbkCardBlurDownsample = 4
 
@@ -195,13 +203,14 @@ fun rememberBlurredCardBackground(
 
 @Composable
 /**
- * Surface tint used by cards/tiles. When a pre-blurred custom background is present the
- * tint stays translucent (capped by [AbkBlurTintAlpha]) so the frosted backdrop shows
- * through even at the default opaque surface alpha; otherwise it follows the regular
+ * Surface tint used by cards/tiles. While the render-custom-background-into-blur feature
+ * is enabled the tint is translucent (capped by [AbkBlurTintAlpha]) regardless of whether
+ * the pre-blurred bitmap has loaded yet, so cards never flash from opaque to translucent
+ * when the frosted backdrop arrives. When the feature is off it follows the regular
  * [uiSurfaceColor] opacity rule.
  */
 fun blurredCardSurfaceColor(color: Color): Color {
-    if (LocalBlurredCardBackground.current == null) return uiSurfaceColor(color)
+    if (!LocalBlurredCardBackgroundEnabled.current) return uiSurfaceColor(color)
     val alpha = (LocalUiSurfaceAlpha.current * AbkBlurTintAlpha).coerceIn(0f, 1f)
     return if (alpha >= 0.995f) color else color.copy(alpha = color.alpha * alpha)
 }

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -1,0 +1,459 @@
+package com.abk.kernel.ui.blur
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import coil.imageLoader
+import coil.request.ImageRequest
+import com.abk.kernel.ui.theme.uiSurfaceColor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Viewport-aligned pre-blurred copy of the custom background shared by cards and tiles
+ * while "将自定义背景渲染到模糊" is enabled.
+ *
+ * Cards sample the rectangle directly beneath them in the shared background
+ * coordinate space. The blur is computed once, while layout callbacks update the
+ * sampled rectangle when cards move.
+ */
+data class BlurredCardBackground(
+    val image: ImageBitmap,
+    val viewportSize: IntSize,
+)
+
+val LocalBlurredCardBackground = compositionLocalOf<BlurredCardBackground?> { null }
+val LocalBlurBackgroundAnchor = compositionLocalOf<LayoutCoordinates?> { null }
+
+internal const val AbkCardBlurRadius = 45f
+private const val AbkCardBlurDownsample = 4
+
+@Composable
+fun rememberBlurredCardBackground(
+    uri: String?,
+    enabled: Boolean,
+): BlurredCardBackground? {
+    val viewportSize = LocalBlurBackgroundAnchor.current?.size
+    val widthPx = viewportSize?.width ?: 0
+    val heightPx = viewportSize?.height ?: 0
+    if (!enabled || uri.isNullOrBlank() || !isBlurCapableDevice() || widthPx <= 0 || heightPx <= 0) {
+        return null
+    }
+    val context = LocalContext.current
+    var bitmap by remember(uri, widthPx, heightPx) { mutableStateOf<BlurredCardBackground?>(null) }
+    LaunchedEffect(uri, widthPx, heightPx) {
+        bitmap = withContext(Dispatchers.Default) {
+            runCatching {
+                val loader = context.imageLoader
+                val result = loader.execute(
+                    ImageRequest.Builder(context).data(uri).allowHardware(false).build()
+                )
+                val source = (result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
+                    ?: return@withContext null
+                blurCoverBitmap(source, AbkCardBlurRadius, widthPx, heightPx)?.let { blurredBitmap ->
+                    BlurredCardBackground(
+                        image = blurredBitmap.asImageBitmap(),
+                        viewportSize = IntSize(widthPx, heightPx),
+                    )
+                }
+            }.getOrNull()
+        }
+    }
+    return bitmap
+}
+
+/**
+ * Surface tint used by cards/tiles. The live "界面不透明度" value is applied
+ * directly, as ReSukiSU applies its card opacity without a separate hard cap.
+ */
+@Composable
+fun blurredCardSurfaceColor(color: Color): Color = uiSurfaceColor(color)
+
+/**
+ * Draws the shared full-screen blurred custom background underneath this surface.
+ * Every card or tile samples its own current screen-space rectangle, so adjacent
+ * and nested surfaces use the same blur strength without inheriting or re-blurring
+ * their parent's pixels.
+ */
+@Composable
+fun Modifier.blurredCardBackground(
+    shape: Shape,
+    enabled: Boolean = true,
+): Modifier = composed {
+    if (!enabled) return@composed this
+    val bitmap = LocalBlurredCardBackground.current ?: return@composed this
+    val backgroundAnchor = LocalBlurBackgroundAnchor.current
+    var coordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var layoutRevision by remember { mutableIntStateOf(0) }
+
+    this
+        .clip(shape)
+        .onGloballyPositioned { newCoordinates ->
+            coordinates = newCoordinates.takeIf { it.isAttached }
+            layoutRevision += 1
+        }
+        .drawWithContent {
+            layoutRevision
+            val boundsInBackground = coordinates?.boundsInBackgroundNow(backgroundAnchor)
+            if (boundsInBackground != null) {
+                drawBitmapIntersection(bitmap, boundsInBackground)
+            }
+            drawContent()
+        }
+}
+
+private fun ContentDrawScope.drawBitmapIntersection(
+    background: BlurredCardBackground,
+    boundsInBackground: Rect,
+) {
+    val bitmap = background.image
+    val viewportWidth = background.viewportSize.width.toFloat()
+    val viewportHeight = background.viewportSize.height.toFloat()
+    if (
+        bitmap.width <= 0 || bitmap.height <= 0 ||
+        viewportWidth <= 0f || viewportHeight <= 0f ||
+        size.width <= 0f || size.height <= 0f ||
+        boundsInBackground.width <= 0f || boundsInBackground.height <= 0f
+    ) return
+
+    val sourceLeft = maxOf(0f, boundsInBackground.left)
+    val sourceTop = maxOf(0f, boundsInBackground.top)
+    val sourceRight = minOf(viewportWidth, boundsInBackground.right)
+    val sourceBottom = minOf(viewportHeight, boundsInBackground.bottom)
+    if (sourceRight <= sourceLeft || sourceBottom <= sourceTop) return
+
+    val bitmapScaleX = bitmap.width / viewportWidth
+    val bitmapScaleY = bitmap.height / viewportHeight
+    val sourceLeftPx = floor(sourceLeft * bitmapScaleX).toInt().coerceIn(0, bitmap.width - 1)
+    val sourceTopPx = floor(sourceTop * bitmapScaleY).toInt().coerceIn(0, bitmap.height - 1)
+    val sourceRightPx = ceil(sourceRight * bitmapScaleX).toInt().coerceIn(sourceLeftPx + 1, bitmap.width)
+    val sourceBottomPx = ceil(sourceBottom * bitmapScaleY).toInt().coerceIn(sourceTopPx + 1, bitmap.height)
+    val destinationLeft = ((sourceLeft - boundsInBackground.left) / boundsInBackground.width * size.width)
+        .roundToInt()
+    val destinationTop = ((sourceTop - boundsInBackground.top) / boundsInBackground.height * size.height)
+        .roundToInt()
+    val destinationRight = ((sourceRight - boundsInBackground.left) / boundsInBackground.width * size.width)
+        .roundToInt()
+    val destinationBottom = ((sourceBottom - boundsInBackground.top) / boundsInBackground.height * size.height)
+        .roundToInt()
+
+    drawImage(
+        image = bitmap,
+        srcOffset = IntOffset(sourceLeftPx, sourceTopPx),
+        srcSize = IntSize(sourceRightPx - sourceLeftPx, sourceBottomPx - sourceTopPx),
+        dstOffset = IntOffset(destinationLeft, destinationTop),
+        dstSize = IntSize(
+            (destinationRight - destinationLeft).coerceAtLeast(1),
+            (destinationBottom - destinationTop).coerceAtLeast(1),
+        ),
+    )
+}
+
+private fun LayoutCoordinates.boundsInBackgroundNow(
+    backgroundCoordinates: LayoutCoordinates?,
+): Rect? {
+    if (!isAttached || size.width <= 0 || size.height <= 0) return null
+    return backgroundCoordinates
+        ?.takeIf { it.isAttached && it.size.width > 0 && it.size.height > 0 }
+        ?.let { boundsInCoordinatesNow(it) }
+        ?: localBoundsInWindowNow()
+}
+
+private fun LayoutCoordinates.boundsInCoordinatesNow(
+    targetCoordinates: LayoutCoordinates,
+): Rect? {
+    fun localToTarget(point: Offset): Offset {
+        val screenPoint = localToScreen(point)
+        if (!screenPoint.x.isFinite() || !screenPoint.y.isFinite()) return Offset.Unspecified
+        return targetCoordinates.screenToLocal(screenPoint)
+    }
+
+    val width = size.width.toFloat()
+    val height = size.height.toFloat()
+    val points = listOf(
+        localToTarget(Offset.Zero),
+        localToTarget(Offset(width, 0f)),
+        localToTarget(Offset(0f, height)),
+        localToTarget(Offset(width, height)),
+    )
+    if (points.any { !it.x.isFinite() || !it.y.isFinite() }) return null
+    return Rect(
+        left = points.minOf { it.x },
+        top = points.minOf { it.y },
+        right = points.maxOf { it.x },
+        bottom = points.maxOf { it.y },
+    )
+}
+
+private fun LayoutCoordinates.localBoundsInWindowNow(): Rect? {
+    val width = size.width.toFloat()
+    val height = size.height.toFloat()
+    val points = listOf(
+        localToWindow(Offset.Zero),
+        localToWindow(Offset(width, 0f)),
+        localToWindow(Offset(0f, height)),
+        localToWindow(Offset(width, height)),
+    )
+    if (points.any { !it.x.isFinite() || !it.y.isFinite() }) return null
+    return Rect(
+        left = points.minOf { it.x },
+        top = points.minOf { it.y },
+        right = points.maxOf { it.x },
+        bottom = points.maxOf { it.y },
+    )
+}
+
+/**
+ * Cover-crops [source] to the viewport and applies the same software blur fallback
+ * used by ReSukiSU for bitmap-backed canvases.
+ */
+private fun blurCoverBitmap(source: Bitmap, radiusPx: Float, viewportW: Int, viewportH: Int): Bitmap? {
+    if (source.isRecycled || viewportW <= 0 || viewportH <= 0) return null
+    val sampleWidth = (viewportW / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+    val sampleHeight = (viewportH / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
+    val work = Bitmap.createBitmap(sampleWidth, sampleHeight, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(work)
+    val scale = max(sampleWidth / source.width.toFloat(), sampleHeight / source.height.toFloat())
+    val matrix = Matrix().apply {
+        setScale(scale, scale)
+        postTranslate((sampleWidth - source.width * scale) / 2f, (sampleHeight - source.height * scale) / 2f)
+    }
+    canvas.drawBitmap(source, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
+    val blurred = work.softwareFastBlur(
+        (radiusPx / AbkCardBlurDownsample).roundToInt().coerceIn(1, 25)
+    )
+    if (blurred !== work) work.recycle()
+    return blurred
+}
+
+/**
+ * StackBlur (Gaussian approximation) ported from ReSukiSU / Mario Klingemann's
+ * classic StackBlur. Works in pure software, no API-level dependencies.
+ */
+private fun Bitmap.softwareFastBlur(radius: Int): Bitmap {
+    if (radius < 1) return this
+
+    val w = width
+    val h = height
+    val pix = IntArray(w * h)
+    getPixels(pix, 0, w, 0, 0, w, h)
+
+    val wm = w - 1
+    val hm = h - 1
+    val wh = w * h
+    val div = radius + radius + 1
+
+    val r = IntArray(wh)
+    val g = IntArray(wh)
+    val b = IntArray(wh)
+    var rsum: Int
+    var gsum: Int
+    var bsum: Int
+    var p: Int
+    var yp: Int
+    var yi: Int
+    val vmin = IntArray(w.coerceAtLeast(h))
+
+    var divsum = (div + 1) shr 1
+    divsum *= divsum
+    val dv = IntArray(256 * divsum)
+    for (i in 0 until 256 * divsum) {
+        dv[i] = i / divsum
+    }
+
+    var yw = 0
+    yi = 0
+
+    val stack = Array(div) { IntArray(3) }
+    var stackpointer: Int
+    var stackstart: Int
+    var sir: IntArray
+    var rbs: Int
+    val r1 = radius + 1
+    var routsum: Int
+    var goutsum: Int
+    var boutsum: Int
+    var rinsum: Int
+    var ginsum: Int
+    var binsum: Int
+
+    for (y in 0 until h) {
+        bsum = 0
+        gsum = 0
+        rsum = 0
+        boutsum = 0
+        goutsum = 0
+        routsum = 0
+        binsum = 0
+        ginsum = 0
+        rinsum = 0
+        for (i in -radius..radius) {
+            p = pix[yi + wm.coerceAtMost(i.coerceAtLeast(0))]
+            sir = stack[i + radius]
+            sir[0] = (p and 0xff0000) shr 16
+            sir[1] = (p and 0x00ff00) shr 8
+            sir[2] = p and 0x0000ff
+            rbs = r1 - abs(i)
+            rsum += sir[0] * rbs
+            gsum += sir[1] * rbs
+            bsum += sir[2] * rbs
+            if (i > 0) {
+                rinsum += sir[0]
+                ginsum += sir[1]
+                binsum += sir[2]
+            } else {
+                routsum += sir[0]
+                goutsum += sir[1]
+                boutsum += sir[2]
+            }
+        }
+        stackpointer = radius
+
+        for (x in 0 until w) {
+            r[yi] = dv[rsum]
+            g[yi] = dv[gsum]
+            b[yi] = dv[bsum]
+
+            rsum -= routsum
+            gsum -= goutsum
+            bsum -= boutsum
+
+            stackstart = stackpointer - radius + div
+            sir = stack[stackstart % div]
+
+            routsum -= sir[0]
+            goutsum -= sir[1]
+            boutsum -= sir[2]
+
+            if (y == 0) vmin[x] = (x + radius + 1).coerceAtMost(wm)
+            p = pix[yw + vmin[x]]
+
+            sir[0] = (p and 0xff0000) shr 16
+            sir[1] = (p and 0x00ff00) shr 8
+            sir[2] = p and 0x0000ff
+
+            rinsum += sir[0]
+            ginsum += sir[1]
+            binsum += sir[2]
+
+            rsum += rinsum
+            gsum += ginsum
+            bsum += binsum
+
+            stackpointer = (stackpointer + 1) % div
+            sir = stack[stackpointer % div]
+
+            routsum += sir[0]
+            goutsum += sir[1]
+            boutsum += sir[2]
+
+            rinsum -= sir[0]
+            ginsum -= sir[1]
+            binsum -= sir[2]
+
+            yi++
+        }
+        yw += w
+    }
+
+    for (x in 0 until w) {
+        bsum = 0
+        gsum = 0
+        rsum = 0
+        boutsum = 0
+        goutsum = 0
+        routsum = 0
+        binsum = 0
+        ginsum = 0
+        rinsum = 0
+        yp = -radius * w
+        for (i in -radius..radius) {
+            yi = yp.coerceAtLeast(0) + x
+            sir = stack[i + radius]
+            sir[0] = r[yi]
+            sir[1] = g[yi]
+            sir[2] = b[yi]
+            rbs = r1 - abs(i)
+            rsum += r[yi] * rbs
+            gsum += g[yi] * rbs
+            bsum += b[yi] * rbs
+            if (i > 0) {
+                rinsum += sir[0]
+                ginsum += sir[1]
+                binsum += sir[2]
+            } else {
+                routsum += sir[0]
+                goutsum += sir[1]
+                boutsum += sir[2]
+            }
+            if (i < hm) yp += w
+        }
+        yi = x
+        stackpointer = radius
+        for (y in 0 until h) {
+            pix[yi] = (-0x1000000 and pix[yi]) or (dv[rsum] shl 16) or (dv[gsum] shl 8) or dv[bsum]
+            rsum -= routsum
+            gsum -= goutsum
+            bsum -= boutsum
+            stackstart = stackpointer - radius + div
+            sir = stack[stackstart % div]
+            routsum -= sir[0]
+            goutsum -= sir[1]
+            boutsum -= sir[2]
+            if (x == 0) vmin[y] = (y + r1).coerceAtMost(hm) * w
+            p = x + vmin[y]
+            sir[0] = r[p]
+            sir[1] = g[p]
+            sir[2] = b[p]
+            rinsum += sir[0]
+            ginsum += sir[1]
+            binsum += sir[2]
+            rsum += rinsum
+            gsum += ginsum
+            bsum += binsum
+            stackpointer = (stackpointer + 1) % div
+            sir = stack[stackpointer]
+            routsum += sir[0]
+            goutsum += sir[1]
+            boutsum += sir[2]
+            rinsum -= sir[0]
+            ginsum -= sir[1]
+            binsum -= sir[2]
+            yi += w
+        }
+    }
+
+    val outputBitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    outputBitmap.setPixels(pix, 0, w, 0, 0, w, h)
+    return outputBitmap
+}

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -107,15 +107,19 @@ private fun blurCacheFile(context: android.content.Context, uri: String): File {
     return File(context.filesDir, "abk_blurred_custom_background_$key.jpg")
 }
 
-/** Deletes the oldest cache entries beyond [AbkBlurCacheMaxFiles], newest first. */
+/** Deletes stale temp files and the oldest cache entries beyond [AbkBlurCacheMaxFiles]. */
 private fun pruneBlurCache(context: android.content.Context) {
     runCatching {
         val prefix = "abk_blurred_custom_background_"
-        context.filesDir.listFiles { file ->
-            file.name.startsWith(prefix) && file.name.endsWith(".jpg")
-        }?.sortedByDescending { it.lastModified() }
-            ?.drop(AbkBlurCacheMaxFiles)
-            ?.forEach { it.delete() }
+        val files = context.filesDir.listFiles { file -> file.name.startsWith(prefix) }
+            ?: return@runCatching
+        // Temp files from an interrupted save are never valid; drop them outright.
+        files.filter { it.name.endsWith(".tmp") }.forEach { it.delete() }
+        // Keep the newest cache entries, newest first.
+        files.filter { it.name.endsWith(".jpg") }
+            .sortedByDescending { it.lastModified() }
+            .drop(AbkBlurCacheMaxFiles)
+            .forEach { it.delete() }
     }
 }
 
@@ -129,7 +133,12 @@ private fun loadBlurCache(
     val file = blurCacheFile(context, uri)
     if (!file.exists()) return null
     return runCatching {
-        val decoded = BitmapFactory.decodeFile(file.absolutePath) ?: return@runCatching null
+        val decoded = BitmapFactory.decodeFile(file.absolutePath)
+        if (decoded == null) {
+            // Corrupt / truncated cache: drop it so it isn't retried on every launch.
+            file.delete()
+            return@runCatching null
+        }
         val expectedW = (viewportW / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
         val expectedH = (viewportH / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
         if (decoded.width != expectedW || decoded.height != expectedH) {
@@ -176,13 +185,11 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
-    // Restarting this effect on every size change cancels the in-flight debounce, so a
-    // rotation / split-screen resize only runs the final decode + StackBlur pass once the
-    // viewport settles. The result goes into the module-level cache, so transient changes
-    // (soft keyboard resizing the window) keep showing the previous frosted backdrop until
-    // the new one is ready, and matching viewports are restored from disk instead of
-    // re-blurring from scratch.
-    LaunchedEffect(uri, enabled, widthPx, heightPx) {
+    // Re-blur only on a WIDTH change (rotation / split-screen). A height-only change is
+    // the IME (adjustResize), where the taller cached bitmap still covers the visible
+    // region, so keying the effect on width (not height) avoids a full decode + StackBlur
+    // pass on every keyboard toggle while still re-blurring real viewport changes.
+    LaunchedEffect(uri, enabled, widthPx) {
         // Wallpaper changed: drop the stale in-memory blur for the old image, but keep its
         // on-disk cache so switching back reuses it (bounded by pruneBlurCache on save,
         // not deleted per change). On a fresh process cachedBlurredCardUri is null, so the
@@ -273,6 +280,7 @@ fun Modifier.blurredCardBackground(
     if (!enabled) return@composed this
     val bitmap = LocalBlurredCardBackground.current ?: return@composed this
     val backgroundAnchor = LocalBlurBackgroundAnchor.current
+    val anchorSize = LocalBlurBackgroundSize.current
     var coordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     var layoutRevision by remember { mutableIntStateOf(0) }
 
@@ -284,9 +292,15 @@ fun Modifier.blurredCardBackground(
         }
         .drawWithContent {
             layoutRevision
-            val boundsInBackground = coordinates?.boundsInBackgroundNow(backgroundAnchor)
-            if (boundsInBackground != null) {
-                drawBitmapIntersection(bitmap, boundsInBackground)
+            // Skip the strip while the cached blur's width is stale (rotation /
+            // split-screen): the old-viewport bitmap would be stretched across the new
+            // bounds. Height-only mismatches (IME) still draw correctly — the taller
+            // bitmap covers the visible region.
+            if (bitmap.viewportSize.width == anchorSize.width) {
+                val boundsInBackground = coordinates?.boundsInBackgroundNow(backgroundAnchor)
+                if (boundsInBackground != null) {
+                    drawBitmapIntersection(bitmap, boundsInBackground)
+                }
             }
             drawContent()
         }

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -185,11 +185,12 @@ fun rememberBlurredCardBackground(
         return null
     }
     val context = LocalContext.current
-    // Re-blur only on a WIDTH change (rotation / split-screen). A height-only change is
-    // the IME (adjustResize), where the taller cached bitmap still covers the visible
-    // region, so keying the effect on width (not height) avoids a full decode + StackBlur
-    // pass on every keyboard toggle while still re-blurring real viewport changes.
-    LaunchedEffect(uri, enabled, widthPx) {
+    // Re-blur whenever the viewport grows past the cached blur, but not for shrink-only
+    // changes (IME, freeform shorter): the cached bitmap is a uniform downsample of its
+    // recorded viewport, so it covers any smaller-or-equal viewport exactly. Keying on
+    // both dimensions makes a real height growth (freeform taller, fold unfold) restart
+    // the effect, while the coverage check below skips the expensive pass for IME shrink.
+    LaunchedEffect(uri, enabled, widthPx, heightPx) {
         // Wallpaper changed: drop the stale in-memory blur for the old image, but keep its
         // on-disk cache so switching back reuses it (bounded by pruneBlurCache on save,
         // not deleted per change). On a fresh process cachedBlurredCardUri is null, so the
@@ -203,8 +204,10 @@ fun rememberBlurredCardBackground(
         if (widthPx <= 0 || heightPx <= 0) return@LaunchedEffect
         val targetWidth = widthPx
         val targetHeight = heightPx
-        // Already have a blur sized for this viewport (e.g. re-entering a known size).
-        if (cachedBlurredCardBackground?.viewportSize == IntSize(targetWidth, targetHeight)) {
+        // Skip only while the cached bitmap still covers the new viewport (shrink / IME);
+        // any dimension that grew past the cached viewport needs a fresh blur.
+        val cached = cachedBlurredCardBackground
+        if (cached != null && cached.viewportSize.width >= targetWidth && cached.viewportSize.height >= targetHeight) {
             return@LaunchedEffect
         }
         val loaded = withContext(Dispatchers.Default) {
@@ -292,11 +295,14 @@ fun Modifier.blurredCardBackground(
         }
         .drawWithContent {
             layoutRevision
-            // Skip the strip while the cached blur's width is stale (rotation /
-            // split-screen): the old-viewport bitmap would be stretched across the new
-            // bounds. Height-only mismatches (IME) still draw correctly — the taller
-            // bitmap covers the visible region.
-            if (bitmap.viewportSize.width == anchorSize.width) {
+            // Draw the strip only while the cached bitmap covers the current anchor. If
+            // the anchor has grown past the cached viewport (rotation / split-screen /
+            // freeform taller, before the re-blur lands), skip so the stale bitmap is not
+            // stretched across the new bounds.
+            if (
+                bitmap.viewportSize.width >= anchorSize.width &&
+                bitmap.viewportSize.height >= anchorSize.height
+            ) {
                 val boundsInBackground = coordinates?.boundsInBackgroundNow(backgroundAnchor)
                 if (boundsInBackground != null) {
                     drawBitmapIntersection(bitmap, boundsInBackground)

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -39,14 +39,7 @@ import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.roundToInt
 
-/**
- * Viewport-aligned pre-blurred copy of the custom background shared by cards and tiles
- * while "将自定义背景渲染到模糊" is enabled.
- *
- * Cards sample the rectangle directly beneath them in the shared background
- * coordinate space. The blur is computed once, while layout callbacks update the
- * sampled rectangle when cards move.
- */
+/** Viewport-aligned pre-blurred custom background copy. */
 data class BlurredCardBackground(
     val image: ImageBitmap,
     val viewportSize: IntSize,
@@ -92,20 +85,12 @@ fun rememberBlurredCardBackground(
     return bitmap
 }
 
-/**
- * Surface tint used by cards/tiles. The live "界面不透明度" value is applied
- * directly, as ReSukiSU applies its card opacity without a separate hard cap.
- */
 @Composable
+/** Surface tint used by cards/tiles. */
 fun blurredCardSurfaceColor(color: Color): Color = uiSurfaceColor(color)
 
-/**
- * Draws the shared full-screen blurred custom background underneath this surface.
- * Every card or tile samples its own current screen-space rectangle, so adjacent
- * and nested surfaces use the same blur strength without inheriting or re-blurring
- * their parent's pixels.
- */
 @Composable
+/** Draws shared blurred custom background underneath this surface. */
 fun Modifier.blurredCardBackground(
     shape: Shape,
     enabled: Boolean = true,
@@ -233,10 +218,6 @@ private fun LayoutCoordinates.localBoundsInWindowNow(): Rect? {
     )
 }
 
-/**
- * Cover-crops [source] to the viewport and applies the same software blur fallback
- * used by ReSukiSU for bitmap-backed canvases.
- */
 private fun blurCoverBitmap(source: Bitmap, radiusPx: Float, viewportW: Int, viewportH: Int): Bitmap? {
     if (source.isRecycled || viewportW <= 0 || viewportH <= 0) return null
     val sampleWidth = (viewportW / AbkCardBlurDownsample.toFloat()).roundToInt().coerceAtLeast(1)
@@ -256,10 +237,6 @@ private fun blurCoverBitmap(source: Bitmap, radiusPx: Float, viewportW: Int, vie
     return blurred
 }
 
-/**
- * StackBlur (Gaussian approximation) ported from ReSukiSU / Mario Klingemann's
- * classic StackBlur. Works in pure software, no API-level dependencies.
- */
 private fun Bitmap.softwareFastBlur(radius: Int): Bitmap {
     if (radius < 1) return this
 

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -142,7 +142,11 @@ fun rememberBlurredCardBackground(
     // re-blurring from scratch.
     LaunchedEffect(uri, enabled, widthPx, heightPx) {
         // Wallpaper changed: drop the stale memory + disk blur for the old image.
-        if (cachedBlurredCardUri != uri) {
+if (cachedBlurredCardUri != null && cachedBlurredCardUri != uri) {
+    cachedBlurredCardBackground = null
+    blurCacheFile(context).delete()
+}
+cachedBlurredCardUri = uri
             cachedBlurredCardBackground = null
             cachedBlurredCardUri = uri
             blurCacheFile(context).delete()

--- a/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
+++ b/app/src/main/java/com/abk/kernel/ui/blur/BlurredCardBackdrop.kt
@@ -62,8 +62,6 @@ fun rememberBlurredCardBackground(
     if (!enabled || uri.isNullOrBlank() || widthPx <= 0 || heightPx <= 0) {
         return null
     }
-        return null
-    }
     val context = LocalContext.current
     var bitmap by remember(uri, widthPx, heightPx) { mutableStateOf<BlurredCardBackground?>(null) }
     LaunchedEffect(uri, widthPx, heightPx) {

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -36,6 +36,8 @@ fun AppBackgroundHost(
     val colorScheme = MaterialTheme.colorScheme
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     // One shared painter for the visible background image and every blur backdrop.
+    // Coil's AsyncImagePainter sizes its request from the onDraw viewport (fillMaxSize),
+    // so a large user wallpaper is decoded at screen resolution, not its original size.
     val backgroundPainter = if (hasBackground) {
         rememberAsyncImagePainter(
             model = backgroundUri,
@@ -58,6 +60,7 @@ fun AppBackgroundHost(
             Image(
                 painter = backgroundPainter,
                 contentDescription = null,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()
             )
         }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -57,10 +57,13 @@ fun AppBackgroundHost(
                 uri = backgroundUri,
                 enabled = blurBackgroundEnabled && hasBackground,
             )
-                LocalUiSurfaceAlpha provides if (hasBackground) uiSurfaceAlpha.coerceIn(0f, 1f) else 1f,
-                LocalAppBackgroundEnabled provides hasBackground,
+            CompositionLocalProvider(
                 LocalBlurredCardBackground provides blurredCardBackground,
-                LocalUiSurfaceAlpha provides uiSurfaceAlpha.coerceIn(0f, 1f),
+                LocalUiSurfaceAlpha provides if (hasBackground) {
+                    uiSurfaceAlpha.coerceIn(0f, 1f)
+                } else {
+                    1f
+                },
                 LocalAppBackgroundEnabled provides hasBackground,
             ) {
                 content()

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -14,9 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.material3.MaterialTheme
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
@@ -40,21 +38,21 @@ fun AppBackgroundHost(
     val colorScheme = MaterialTheme.colorScheme
     val context = LocalContext.current
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
     // One shared painter for the visible background image and every blur backdrop.
-    // The request is explicitly bounded to this host's viewport size (from onSizeChanged)
-    // so a large user wallpaper is decoded at screen resolution instead of its original
-    // dimensions. The request is cached on (uri, viewportSize) so it is rebuilt only when
-    // the wallpaper or the viewport actually changes.
+    // Decode the wallpaper at full-screen resolution, which is stable across transient
+    // insets (soft keyboard / IME resizing the window): a large user image is never
+    // decoded at its original size, and an IME opening does not re-decode the wallpaper
+    // (which would flash the background to empty while it reloads).
+    val displayMetrics = context.resources.displayMetrics
     val backgroundPainter = if (hasBackground) {
-        val request = remember(backgroundUri, viewportSize) {
+        val request = remember(
+            backgroundUri,
+            displayMetrics.widthPixels,
+            displayMetrics.heightPixels,
+        ) {
             ImageRequest.Builder(context)
                 .data(backgroundUri)
-                .apply {
-                    if (viewportSize.width > 0 && viewportSize.height > 0) {
-                        size(viewportSize.width, viewportSize.height)
-                    }
-                }
+                .size(displayMetrics.widthPixels, displayMetrics.heightPixels)
                 .build()
         }
         rememberAsyncImagePainter(
@@ -67,7 +65,6 @@ fun AppBackgroundHost(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .onSizeChanged { viewportSize = it }
             .onGloballyPositioned { coordinates ->
                 if (backgroundCoordinates !== coordinates) {
                     backgroundCoordinates = coordinates.takeIf { it.isAttached }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -1,5 +1,6 @@
 package com.abk.kernel.ui.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +16,9 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.material3.MaterialTheme
 import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
 import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
+import com.abk.kernel.ui.blur.LocalBlurredBackgroundPainter
 import com.abk.kernel.ui.blur.LocalBlurredCardBackground
 import com.abk.kernel.ui.blur.rememberBlurredCardBackground
 import com.abk.kernel.ui.theme.LocalAppBackgroundEnabled
@@ -32,6 +35,15 @@ fun AppBackgroundHost(
     val hasBackground = backgroundEnabled && !backgroundUri.isNullOrBlank()
     val colorScheme = MaterialTheme.colorScheme
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    // One shared painter for the visible background image and every blur backdrop.
+    val backgroundPainter = if (hasBackground) {
+        rememberAsyncImagePainter(
+            model = backgroundUri,
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        null
+    }
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -42,16 +54,16 @@ fun AppBackgroundHost(
             }
             .background(colorScheme.surface)
     ) {
-        if (hasBackground) {
-            AsyncImage(
-                model = backgroundUri,
+        if (backgroundPainter != null) {
+            Image(
+                painter = backgroundPainter,
                 contentDescription = null,
-                contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()
             )
         }
         CompositionLocalProvider(
             LocalBlurBackgroundAnchor provides backgroundCoordinates,
+            LocalBlurredBackgroundPainter provides backgroundPainter,
         ) {
             val blurredCardBackground = rememberBlurredCardBackground(
                 uri = backgroundUri,

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -15,12 +15,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.material3.MaterialTheme
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
+import com.abk.kernel.ui.blur.LocalBlurBackgroundSize
 import com.abk.kernel.ui.blur.LocalBlurredBackgroundPainter
 import com.abk.kernel.ui.blur.LocalBlurredCardBackground
 import com.abk.kernel.ui.blur.LocalBlurredCardBackgroundEnabled
@@ -40,6 +42,7 @@ fun AppBackgroundHost(
     val colorScheme = MaterialTheme.colorScheme
     val context = LocalContext.current
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var backgroundSize by remember { mutableStateOf(IntSize.Zero) }
     // One shared painter for the visible background image and every blur backdrop.
     // Decode the wallpaper at full-screen resolution, which is stable across transient
     // insets (soft keyboard / IME resizing the window): a large user image is never
@@ -71,6 +74,12 @@ fun AppBackgroundHost(
                 if (backgroundCoordinates !== coordinates) {
                     backgroundCoordinates = coordinates.takeIf { it.isAttached }
                 }
+                // LayoutCoordinates.size is not snapshot-backed, so reading it in
+                // composition does not resubscribe when the anchor relayouts to a new
+                // size (split-screen / IME resize). Mirror it into observable state.
+                if (coordinates.isAttached && coordinates.size != backgroundSize) {
+                    backgroundSize = coordinates.size
+                }
             }
             .background(colorScheme.surface)
     ) {
@@ -84,6 +93,7 @@ fun AppBackgroundHost(
         }
         CompositionLocalProvider(
             LocalBlurBackgroundAnchor provides backgroundCoordinates,
+            LocalBlurBackgroundSize provides backgroundSize,
             LocalBlurredBackgroundPainter provides backgroundPainter,
         ) {
             val blurredCardBackground = rememberBlurredCardBackground(

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -5,10 +5,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.material3.MaterialTheme
 import coil.compose.AsyncImage
+import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
+import com.abk.kernel.ui.blur.LocalBlurredCardBackground
+import com.abk.kernel.ui.blur.rememberBlurredCardBackground
 import com.abk.kernel.ui.theme.LocalAppBackgroundEnabled
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
 
@@ -17,13 +26,20 @@ fun AppBackgroundHost(
     backgroundUri: String?,
     backgroundEnabled: Boolean,
     uiSurfaceAlpha: Float,
+    blurBackgroundEnabled: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val hasBackground = backgroundEnabled && !backgroundUri.isNullOrBlank()
     val colorScheme = MaterialTheme.colorScheme
+    var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .onGloballyPositioned { coordinates ->
+                if (backgroundCoordinates !== coordinates) {
+                    backgroundCoordinates = coordinates.takeIf { it.isAttached }
+                }
+            }
             .background(colorScheme.surface)
     ) {
         if (hasBackground) {
@@ -35,10 +51,19 @@ fun AppBackgroundHost(
             )
         }
         CompositionLocalProvider(
-            LocalUiSurfaceAlpha provides if (hasBackground) uiSurfaceAlpha.coerceIn(0f, 1f) else 1f,
-            LocalAppBackgroundEnabled provides hasBackground
+            LocalBlurBackgroundAnchor provides backgroundCoordinates,
         ) {
-            content()
+            val blurredCardBackground = rememberBlurredCardBackground(
+                uri = backgroundUri,
+                enabled = blurBackgroundEnabled && hasBackground,
+            )
+            CompositionLocalProvider(
+                LocalBlurredCardBackground provides blurredCardBackground,
+                LocalUiSurfaceAlpha provides uiSurfaceAlpha.coerceIn(0f, 1f),
+                LocalAppBackgroundEnabled provides hasBackground,
+            ) {
+                content()
+            }
         }
     }
 }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -53,6 +53,10 @@ fun AppBackgroundHost(
             ImageRequest.Builder(context)
                 .data(backgroundUri)
                 .size(displayMetrics.widthPixels, displayMetrics.heightPixels)
+                // Software bitmap so the blurred-card backdrop can reuse this exact
+                // decoded bitmap (hardware bitmaps can't be sampled by the StackBlur
+                // pass). Keeps the wallpaper to a single decode.
+                .allowHardware(false)
                 .build()
         }
         rememberAsyncImagePainter(
@@ -118,18 +122,34 @@ fun AppPageBackground(
     modifier: Modifier = Modifier
 ) {
     val hasBackground = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+    val sharedPainter = LocalBlurredBackgroundPainter.current
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
     ) {
         if (hasBackground) {
-            AsyncImage(
-                model = backgroundUri,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
-            )
+            // Reuse the wallpaper painter already decoded by the enclosing
+            // AppBackgroundHost instead of issuing a second Coil request. A separate
+            // AsyncImage here has a distinct cache key (it requests the original size)
+            // and no placeholder, so on low-end devices the child page flashes the
+            // opaque surface (black in dark theme) before the wallpaper lands. Sharing
+            // the painter keeps the wallpaper on screen from the first frame.
+            if (sharedPainter != null) {
+                Image(
+                    painter = sharedPainter,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                AsyncImage(
+                    model = backgroundUri,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -14,9 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.material3.MaterialTheme
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
 import com.abk.kernel.ui.blur.LocalBlurredBackgroundPainter
 import com.abk.kernel.ui.blur.LocalBlurredCardBackground
@@ -34,13 +38,27 @@ fun AppBackgroundHost(
 ) {
     val hasBackground = backgroundEnabled && !backgroundUri.isNullOrBlank()
     val colorScheme = MaterialTheme.colorScheme
+    val context = LocalContext.current
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
     // One shared painter for the visible background image and every blur backdrop.
-    // Coil's AsyncImagePainter sizes its request from the onDraw viewport (fillMaxSize),
-    // so a large user wallpaper is decoded at screen resolution, not its original size.
+    // The request is explicitly bounded to this host's viewport size (from onSizeChanged)
+    // so a large user wallpaper is decoded at screen resolution instead of its original
+    // dimensions. The request is cached on (uri, viewportSize) so it is rebuilt only when
+    // the wallpaper or the viewport actually changes.
     val backgroundPainter = if (hasBackground) {
+        val request = remember(backgroundUri, viewportSize) {
+            ImageRequest.Builder(context)
+                .data(backgroundUri)
+                .apply {
+                    if (viewportSize.width > 0 && viewportSize.height > 0) {
+                        size(viewportSize.width, viewportSize.height)
+                    }
+                }
+                .build()
+        }
         rememberAsyncImagePainter(
-            model = backgroundUri,
+            model = request,
             contentScale = ContentScale.Crop,
         )
     } else {
@@ -49,6 +67,7 @@ fun AppBackgroundHost(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .onSizeChanged { viewportSize = it }
             .onGloballyPositioned { coordinates ->
                 if (backgroundCoordinates !== coordinates) {
                     backgroundCoordinates = coordinates.takeIf { it.isAttached }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -99,7 +100,16 @@ fun AppBackgroundHost(
                 },
                 LocalAppBackgroundEnabled provides hasBackground,
             ) {
-                content()
+                // adjustNothing keeps the window (and the wallpaper/backdrop layer) from
+                // resizing when the IME opens, so the frosted backdrop never re-blurs on
+                // keyboard show/hide. Push the app content up over the IME instead.
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .imePadding()
+                ) {
+                    content()
+                }
             }
         }
     }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -42,11 +42,7 @@ fun AppBackgroundHost(
     val context = LocalContext.current
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     var backgroundSize by remember { mutableStateOf(IntSize.Zero) }
-    // One shared painter for the visible background image and every blur backdrop.
-    // Decode the wallpaper at full-screen resolution, which is stable across transient
-    // insets (soft keyboard / IME resizing the window): a large user image is never
-    // decoded at its original size, and an IME opening does not re-decode the wallpaper
-    // (which would flash the background to empty while it reloads).
+    // Decode at display size (stable across IME insets), never at the image's original size.
     val displayMetrics = context.resources.displayMetrics
     val backgroundPainter = if (hasBackground) {
         val request = remember(
@@ -73,9 +69,7 @@ fun AppBackgroundHost(
                 if (backgroundCoordinates !== coordinates) {
                     backgroundCoordinates = coordinates.takeIf { it.isAttached }
                 }
-                // LayoutCoordinates.size is not snapshot-backed, so reading it in
-                // composition does not resubscribe when the anchor relayouts to a new
-                // size (split-screen / IME resize). Mirror it into observable state.
+                // LayoutCoordinates.size is not observable; mirror it into state.
                 if (coordinates.isAttached && coordinates.size != backgroundSize) {
                     backgroundSize = coordinates.size
                 }
@@ -109,9 +103,6 @@ fun AppBackgroundHost(
                 },
                 LocalAppBackgroundEnabled provides hasBackground,
             ) {
-                // adjustResize keeps the window content above the IME; the card-blur
-                // backdrop keys its re-blur on width (not height), so an IME height change
-                // does not re-run the decode + StackBlur pass.
                 Box(Modifier.fillMaxSize()) {
                     content()
                 }

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -57,7 +57,8 @@ fun AppBackgroundHost(
                 uri = backgroundUri,
                 enabled = blurBackgroundEnabled && hasBackground,
             )
-            CompositionLocalProvider(
+                LocalUiSurfaceAlpha provides if (hasBackground) uiSurfaceAlpha.coerceIn(0f, 1f) else 1f,
+                LocalAppBackgroundEnabled provides hasBackground,
                 LocalBlurredCardBackground provides blurredCardBackground,
                 LocalUiSurfaceAlpha provides uiSurfaceAlpha.coerceIn(0f, 1f),
                 LocalAppBackgroundEnabled provides hasBackground,

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -22,6 +22,7 @@ import coil.request.ImageRequest
 import com.abk.kernel.ui.blur.LocalBlurBackgroundAnchor
 import com.abk.kernel.ui.blur.LocalBlurredBackgroundPainter
 import com.abk.kernel.ui.blur.LocalBlurredCardBackground
+import com.abk.kernel.ui.blur.LocalBlurredCardBackgroundEnabled
 import com.abk.kernel.ui.blur.rememberBlurredCardBackground
 import com.abk.kernel.ui.theme.LocalAppBackgroundEnabled
 import com.abk.kernel.ui.theme.LocalUiSurfaceAlpha
@@ -90,6 +91,7 @@ fun AppBackgroundHost(
             )
             CompositionLocalProvider(
                 LocalBlurredCardBackground provides blurredCardBackground,
+                LocalBlurredCardBackgroundEnabled provides (blurBackgroundEnabled && hasBackground),
                 LocalUiSurfaceAlpha provides if (hasBackground) {
                     uiSurfaceAlpha.coerceIn(0f, 1f)
                 } else {

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -41,9 +41,14 @@ fun AppBackgroundHost(
     val colorScheme = MaterialTheme.colorScheme
     val context = LocalContext.current
     var backgroundCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    var backgroundSize by remember { mutableStateOf(IntSize.Zero) }
     // Decode at display size (stable across IME insets), never at the image's original size.
     val displayMetrics = context.resources.displayMetrics
+    // Seed the viewport from display metrics so the blurred-card backdrop can start
+    // loading on the very first composition instead of waiting for onGloballyPositioned.
+    val initialBackgroundSize = remember(displayMetrics.widthPixels, displayMetrics.heightPixels) {
+        IntSize(displayMetrics.widthPixels, displayMetrics.heightPixels)
+    }
+    var backgroundSize by remember(initialBackgroundSize) { mutableStateOf(initialBackgroundSize) }
     val backgroundPainter = if (hasBackground) {
         val request = remember(
             backgroundUri,
@@ -57,6 +62,8 @@ fun AppBackgroundHost(
                 // decoded bitmap (hardware bitmaps can't be sampled by the StackBlur
                 // pass). Keeps the wallpaper to a single decode.
                 .allowHardware(false)
+                // Fade the wallpaper in over the neutral surface instead of popping in.
+                .crossfade(true)
                 .build()
         }
         rememberAsyncImagePainter(
@@ -78,7 +85,13 @@ fun AppBackgroundHost(
                     backgroundSize = coordinates.size
                 }
             }
-            .background(colorScheme.surface)
+            // While a wallpaper is configured, wait on a slightly lighter neutral than
+            // surface: on a cold start the decode lands a frame or two later, and pure
+            // black behind translucent frosted surfaces reads as a black flash (this
+            // mirrors ReSukiSU's use of surfaceContainer as the pre-load color).
+            .background(
+                if (hasBackground) colorScheme.surfaceContainer else colorScheme.surface
+            )
     ) {
         if (backgroundPainter != null) {
             Image(

--- a/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/AppBackgroundHost.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -110,14 +109,10 @@ fun AppBackgroundHost(
                 },
                 LocalAppBackgroundEnabled provides hasBackground,
             ) {
-                // adjustNothing keeps the window (and the wallpaper/backdrop layer) from
-                // resizing when the IME opens, so the frosted backdrop never re-blurs on
-                // keyboard show/hide. Push the app content up over the IME instead.
-                Box(
-                    Modifier
-                        .fillMaxSize()
-                        .imePadding()
-                ) {
+                // adjustResize keeps the window content above the IME; the card-blur
+                // backdrop keys its re-blur on width (not height), so an IME height change
+                // does not re-run the decode + StackBlur pass.
+                Box(Modifier.fillMaxSize()) {
                     content()
                 }
             }

--- a/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.abk.kernel.R
-import com.abk.kernel.ui.blur.LocalBlurredCardBackground
+import com.abk.kernel.ui.blur.LocalBlurredCardBackgroundEnabled
 import com.abk.kernel.ui.blur.blurredCardBackground
 import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.theme.uiSurfaceColor
@@ -196,7 +196,10 @@ fun ExpressiveListItem(
     onClick: (() -> Unit)? = null
 ) {
     val colors = MaterialTheme.colorScheme
-    val drawsOwnBlurSurface = LocalBlurredCardBackground.current != null
+    // Follow the synchronous "feature enabled" signal, not the async bitmap readiness, so
+    // rows keep a surface tint from the first frame and don't flash transparent→tinted
+    // while the pre-blurred background loads.
+    val drawsOwnBlurSurface = LocalBlurredCardBackgroundEnabled.current
     val containerColor = when {
         selected -> blurredCardSurfaceColor(colors.primaryContainer)
         drawsOwnBlurSurface -> blurredCardSurfaceColor(colors.surfaceContainer)

--- a/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
@@ -28,6 +28,12 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,7 +45,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.abk.kernel.R
+import com.abk.kernel.ui.blur.LocalBlurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.theme.uiSurfaceColor
+
+private val LocalBlurredSurfaceDepth = compositionLocalOf { 0 }
 
 @Composable
 fun ExpressiveHeroCard(
@@ -52,58 +63,66 @@ fun ExpressiveHeroCard(
     badge: (@Composable RowScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit = {}
 ) {
+    val blurDepth = LocalBlurredSurfaceDepth.current
     Card(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .blurredCardBackground(
+                shape = MaterialTheme.shapes.medium,
+                enabled = true,
+            ),
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(containerColor),
+            containerColor = blurredCardSurfaceColor(containerColor),
             contentColor = contentColor
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .animateContentSize(),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+        CompositionLocalProvider(LocalBlurredSurfaceDepth provides blurDepth + 1) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .animateContentSize(),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = contentColor,
-                    modifier = Modifier.size(22.dp)
-                )
-                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = contentColor,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = contentColor,
+                        modifier = Modifier.size(22.dp)
                     )
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = contentColor.copy(alpha = 0.76f)
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = contentColor,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = contentColor.copy(alpha = 0.76f)
+                        )
+                    }
+                }
+                if (badge != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        content = badge
                     )
                 }
+                content()
             }
-            if (badge != null) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    content = badge
-                )
-            }
-            content()
         }
     }
 }
@@ -118,50 +137,58 @@ fun ExpressiveSectionCard(
     containerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
     content: @Composable ColumnScope.() -> Unit
 ) {
+    val blurDepth = LocalBlurredSurfaceDepth.current
     Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = uiSurfaceColor(containerColor)),
+        modifier = modifier
+            .fillMaxWidth()
+            .blurredCardBackground(
+                shape = MaterialTheme.shapes.large,
+                enabled = true,
+            ),
+        colors = CardDefaults.cardColors(containerColor = blurredCardSurfaceColor(containerColor)),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(14.dp)
-                .animateContentSize(),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+        CompositionLocalProvider(LocalBlurredSurfaceDepth provides blurDepth + 1) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(14.dp)
+                    .animateContentSize(),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                if (icon != null) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    if (subtitle != null) {
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    if (icon != null) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.size(20.dp)
                         )
                     }
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        if (subtitle != null) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (trailingContent != null) {
+                        trailingContent()
+                    }
                 }
-                if (trailingContent != null) {
-                    trailingContent()
-                }
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp), content = content)
             }
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp), content = content)
         }
     }
 }
@@ -179,8 +206,11 @@ fun ExpressiveListItem(
     onClick: (() -> Unit)? = null
 ) {
     val colors = MaterialTheme.colorScheme
+    val blurDepth = LocalBlurredSurfaceDepth.current
+    val drawsOwnBlurSurface = LocalBlurredCardBackground.current != null
     val containerColor = when {
-        selected -> uiSurfaceColor(colors.primaryContainer)
+        selected -> blurredCardSurfaceColor(colors.primaryContainer)
+        drawsOwnBlurSurface -> blurredCardSurfaceColor(colors.surfaceContainer)
         else -> Color.Transparent
     }
     val titleColor = when {
@@ -207,6 +237,10 @@ fun ExpressiveListItem(
         modifier = modifier
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.large)
+            .blurredCardBackground(
+                shape = MaterialTheme.shapes.large,
+                enabled = true,
+            )
             .then(clickableModifier),
         headlineContent = {
             Text(

--- a/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/ExpressiveCards.kt
@@ -28,8 +28,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,8 +48,6 @@ import com.abk.kernel.ui.blur.blurredCardBackground
 import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.theme.uiSurfaceColor
 
-private val LocalBlurredSurfaceDepth = compositionLocalOf { 0 }
-
 @Composable
 fun ExpressiveHeroCard(
     title: String,
@@ -63,7 +59,6 @@ fun ExpressiveHeroCard(
     badge: (@Composable RowScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit = {}
 ) {
-    val blurDepth = LocalBlurredSurfaceDepth.current
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -77,52 +72,50 @@ fun ExpressiveHeroCard(
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        CompositionLocalProvider(LocalBlurredSurfaceDepth provides blurDepth + 1) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .animateContentSize(),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .animateContentSize(),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                        tint = contentColor,
-                        modifier = Modifier.size(22.dp)
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp)
+                )
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = contentColor,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
                     )
-                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text(
-                            text = title,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = contentColor,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = contentColor.copy(alpha = 0.76f)
-                        )
-                    }
-                }
-                if (badge != null) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        content = badge
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = contentColor.copy(alpha = 0.76f)
                     )
                 }
-                content()
             }
+            if (badge != null) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    content = badge
+                )
+            }
+            content()
         }
     }
 }
@@ -137,7 +130,6 @@ fun ExpressiveSectionCard(
     containerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    val blurDepth = LocalBlurredSurfaceDepth.current
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -148,47 +140,45 @@ fun ExpressiveSectionCard(
         colors = CardDefaults.cardColors(containerColor = blurredCardSurfaceColor(containerColor)),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        CompositionLocalProvider(LocalBlurredSurfaceDepth provides blurDepth + 1) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(14.dp)
-                    .animateContentSize(),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp)
+                .animateContentSize(),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    if (icon != null) {
-                        Icon(
-                            imageVector = icon,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
-                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                if (icon != null) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    if (subtitle != null) {
                         Text(
-                            text = title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        if (subtitle != null) {
-                            Text(
-                                text = subtitle,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    if (trailingContent != null) {
-                        trailingContent()
                     }
                 }
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp), content = content)
+                if (trailingContent != null) {
+                    trailingContent()
+                }
             }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp), content = content)
         }
     }
 }
@@ -206,7 +196,6 @@ fun ExpressiveListItem(
     onClick: (() -> Unit)? = null
 ) {
     val colors = MaterialTheme.colorScheme
-    val blurDepth = LocalBlurredSurfaceDepth.current
     val drawsOwnBlurSurface = LocalBlurredCardBackground.current != null
     val containerColor = when {
         selected -> blurredCardSurfaceColor(colors.primaryContainer)

--- a/app/src/main/java/com/abk/kernel/ui/components/ExpressiveTopBar.kt
+++ b/app/src/main/java/com/abk/kernel/ui/components/ExpressiveTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -31,6 +32,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.abk.kernel.ui.blur.blurEffect
+import com.abk.kernel.ui.blur.isBlurActive
 import com.abk.kernel.ui.theme.uiSurfaceColor
 
 val AbkScreenHorizontalPadding: Dp = 24.dp
@@ -46,6 +49,7 @@ fun ExpressiveFlexibleTopBar(
     navigationIcon: @Composable (() -> Unit)? = null,
     compactTitle: Boolean = false,
     scrollBehavior: TopAppBarScrollBehavior? = null,
+    enableBlur: Boolean = false,
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     ExpressiveTopBar(
@@ -54,6 +58,7 @@ fun ExpressiveFlexibleTopBar(
         navigationIcon = navigationIcon,
         compactTitle = compactTitle,
         scrollBehavior = scrollBehavior,
+        enableBlur = enableBlur,
         actions = actions
     )
 }
@@ -67,6 +72,7 @@ fun ExpressiveTopBar(
     compactTitle: Boolean = false,
     collapsing: Boolean = true,
     scrollBehavior: TopAppBarScrollBehavior? = null,
+    enableBlur: Boolean = false,
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     val hasNavigation = navigationIcon != null
@@ -124,10 +130,13 @@ fun ExpressiveTopBar(
             fontWeight = FontWeight.Normal,
             letterSpacing = 0.sp
         )
+    val blurActive = isBlurActive(enableBlur)
 
     Surface(
-        modifier = modifier.fillMaxWidth(),
-        color = uiSurfaceColor(MaterialTheme.colorScheme.surface),
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (blurActive) Modifier.blurEffect() else Modifier),
+        color = if (blurActive) Color.Transparent else uiSurfaceColor(MaterialTheme.colorScheme.surface),
         contentColor = MaterialTheme.colorScheme.onSurface
     ) {
         Column(

--- a/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/AbkRootPatchScreen.kt
@@ -69,7 +69,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -95,11 +94,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.abk.kernel.R
+import com.abk.kernel.ui.blur.BlurConfig
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AppPageBackground
 import com.abk.kernel.ui.components.ExpressiveListItem
 import com.abk.kernel.ui.components.ExpressiveTopBar
-import com.abk.kernel.ui.theme.uiSurfaceColor
 import com.abk.kernel.utils.RootUtils
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -120,6 +122,8 @@ fun AbkRootPatchScreen(
     runtimeVariant: String,
     backgroundUri: String?,
     backgroundImageEnabled: Boolean,
+    blurEnabled: Boolean,
+    blurBackgroundExpEnabled: Boolean,
     onBack: () -> Unit,
     onBackEnabledChange: (Boolean) -> Unit = {},
     downloadDirectory: String? = null
@@ -488,7 +492,13 @@ fun AbkRootPatchScreen(
             backgroundUri = backgroundUri,
             backgroundImageEnabled = backgroundImageEnabled
         )
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = BlurConfig(
+                blurEnabled = blurEnabled,
+                backgroundExpEnabled = blurBackgroundExpEnabled,
+                backgroundUri = backgroundUri,
+                backgroundImageEnabled = backgroundImageEnabled,
+            ),
             containerColor = Color.Transparent,
             topBar = {
                 ExpressiveTopBar(
@@ -497,19 +507,19 @@ fun AbkRootPatchScreen(
                         IconButton(onClick = onBack, enabled = !running) {
                             Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.back))
                         }
-                    }
+                    },
+                    enableBlur = blurEnabled
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             Column(
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = AbkScreenHorizontalPadding)
-                    .padding(top = 12.dp),
+                    .padding(horizontal = AbkScreenHorizontalPadding),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
+            Spacer(Modifier.height(topBarHeight + 16.dp))
             PatchGroupCard {
                 PatchModeRow(
                     title = stringResource(R.string.root_patch_select_file),
@@ -850,10 +860,14 @@ private fun LkmPatchPageBackground(
 
 @Composable
 private fun PatchGroupCard(content: @Composable ColumnScope.() -> Unit) {
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
@@ -938,12 +952,16 @@ private fun PatchedImageCard(
     onCopy: () -> Unit,
     onFlash: () -> Unit
 ) {
+    val shape = MaterialTheme.shapes.medium
     Card(
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape
     ) {
         Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -985,10 +1003,14 @@ private fun PatchLogCard(
     canReboot: Boolean,
     onReboot: () -> Unit
 ) {
+    val shape = MaterialTheme.shapes.medium
     Card(
-        colors = CardDefaults.cardColors(containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)),
+        colors = CardDefaults.cardColors(containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape
     ) {
         Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/BuildScreen.kt
@@ -77,6 +77,9 @@ import com.abk.kernel.data.model.WorkflowRun
 import com.abk.kernel.data.model.isKernelBuild
 import com.abk.kernel.data.model.isManagerBuild
 import com.abk.kernel.data.model.isManagerDevBuild
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AbkSegmentedButtonOption
 import com.abk.kernel.ui.components.AbkSingleChoiceSegmentedButtonRow
@@ -1028,23 +1031,25 @@ fun BuildScreen(
 
     if (!state.isLoggedIn || state.forkRepo == null) {
         val needsLogin = !state.isLoggedIn
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = stringResource(R.string.build_title),
-                    scrollBehavior = scrollBehavior
+                    scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             Column(
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .padding(horizontal = AbkScreenHorizontalPadding)
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
+                Spacer(Modifier.height(topBarHeight + 16.dp))
                 ExpressiveHeroCard(
                     title = stringResource(
                         if (needsLogin) {
@@ -1108,29 +1113,31 @@ fun BuildScreen(
             .fillMaxWidth()
             .height(maxHeight + childPageTopInset + childPageBottomInset)
             .offset(y = -childPageTopInset)
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = stringResource(R.string.build_title),
-                    scrollBehavior = scrollBehavior
+                    scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             Column(
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = AbkScreenHorizontalPadding),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-            BuildPlanHero(
-                config,
-                recommended,
-                state.buildStatus
-            )
+                Spacer(Modifier.height(topBarHeight + 16.dp))
+                BuildPlanHero(
+                    config,
+                    recommended,
+                    state.buildStatus
+                )
 
             BuildPlanToolsCard(
                 plansCount = state.buildPlans.size,
@@ -1749,9 +1756,12 @@ fun BuildScreen(
                         }
 
                         state.customExternalModuleError?.let { err ->
+                            val shape = MaterialTheme.shapes.medium
                             Card(
+                                modifier = Modifier.blurredCardBackground(shape),
+                                shape = shape,
                                 colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.errorContainer
+                                    containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.errorContainer)
                                 )
                             ) {
                                 Row(
@@ -1855,7 +1865,8 @@ fun BuildScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -1869,6 +1880,7 @@ fun BuildScreen(
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.build_back_to_config))
                                 }
                             },
+                            enableBlur = state.blurEnabled,
                             actions = {
                                 if (showKernelOptionsPage) {
                                     Box {
@@ -1920,9 +1932,10 @@ fun BuildScreen(
                             }
                         )
                     }
-                ) { padding ->
+                ) { topBarHeight ->
                     if (showBuildQueuePage) {
                         BuildQueuePage(
+                            topBarHeight = topBarHeight,
                             queue = state.buildQueue,
                             cancellingRunIds = state.cancellingWorkflowRunIds,
                             onApply = {
@@ -1934,13 +1947,11 @@ fun BuildScreen(
                             onRetry = { vm.retryBuildQueueItem(it.id) },
                             onCancelRun = { runId -> vm.cancelWorkflowRun(runId) },
                             onClearCompleted = vm::clearCompletedBuildQueueItems,
-                            modifier = Modifier
-                                .padding(padding)
-                                .fillMaxSize()
+                            modifier = Modifier.fillMaxSize()
                         )
                     } else if (showKernelOptionsPage) {
                         BuildKernelOptionsPage(
-                            padding = padding,
+                            topBarHeight = topBarHeight,
                             options = filteredKernelOptions,
                             summary = kernelOptionSummary,
                             searchQuery = kernelOptionSearchQuery,
@@ -1955,6 +1966,7 @@ fun BuildScreen(
                         )
                     } else {
                         BuildPlanLibraryPage(
+                            topBarHeight = topBarHeight,
                             plans = state.buildPlans,
                             onApply = {
                                 vm.applyBuildPlan(it)
@@ -1967,9 +1979,7 @@ fun BuildScreen(
                                 renamePlanName = it.name
                             },
                             onDelete = { deletePlanTarget = it },
-                            modifier = Modifier
-                                .padding(padding)
-                                .fillMaxSize()
+                            modifier = Modifier.fillMaxSize()
                         )
                     }
                 }
@@ -2257,6 +2267,7 @@ private fun ShareBuildPlanScopeDialog(
 
 @Composable
 private fun BuildPlanLibraryPage(
+    topBarHeight: Dp,
     plans: List<BuildPlan>,
     onApply: (BuildPlan) -> Unit,
     onShare: (BuildPlan) -> Unit,
@@ -2270,6 +2281,7 @@ private fun BuildPlanLibraryPage(
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         if (plans.isEmpty()) {
             ExpressiveSectionCard(
                 title = stringResource(R.string.build_no_plans),
@@ -2352,6 +2364,7 @@ private fun BuildPlanLibraryItem(
 
 @Composable
 private fun BuildQueuePage(
+    topBarHeight: Dp,
     queue: List<BuildQueueItem>,
     cancellingRunIds: Set<Long>,
     onApply: (BuildQueueItem) -> Unit,
@@ -2368,6 +2381,7 @@ private fun BuildQueuePage(
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         ExpressiveSectionCard(
             title = stringResource(R.string.build_queue_status),
             subtitle = if (queue.isEmpty()) {
@@ -2699,7 +2713,7 @@ private fun formatCustomKernelImportSummary(context: Context, result: CustomKern
 
 @Composable
 private fun BuildKernelOptionsPage(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     options: List<IndexedValue<CustomKernelOption>>,
     summary: CustomKernelOptionSummary,
     searchQuery: String,
@@ -2710,11 +2724,10 @@ private fun BuildKernelOptionsPage(
 ) {
     LazyColumn(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(10.dp),
-        contentPadding = PaddingValues(bottom = bottomPadding + 24.dp)
+        contentPadding = PaddingValues(top = topBarHeight + 16.dp, bottom = bottomPadding + 24.dp)
     ) {
         item(key = "search") {
             BuildKernelOptionSearchField(
@@ -3295,10 +3308,14 @@ private fun BuildStatusBanner(
         BuildStatus.CANCELLED -> Triple(Icons.Default.Cancel, stringResource(R.string.build_cancelled), MaterialTheme.colorScheme.outline)
         else -> return
     }
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Row(
@@ -3363,10 +3380,15 @@ private fun BuildProgressCard(
         animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
         label = "build-progress"
     )
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth().animateContentSize(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/FlashScreen.kt
@@ -106,7 +106,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -188,6 +187,7 @@ import com.abk.kernel.utils.FlashFilterManagerKind
 import com.abk.kernel.utils.FlashFilterWorkflowState
 import com.abk.kernel.utils.FlashWorkflowFilter
 import com.abk.kernel.utils.WorkflowPrimary
+import com.abk.kernel.ui.blur.BlurScreenScaffold
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.rememberAbkInteractiveRefreshPresentation
 import com.abk.kernel.ui.components.ObserveChildPageVisibility
@@ -1120,24 +1120,25 @@ fun FlashScreen(
         )
         val showPrebuiltReleaseRefreshLoading =
             prebuiltReleaseRefreshPresentation.showLoading && state.prebuiltGkiReleases.isNotEmpty()
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = Color.Transparent,
             topBar = {
                 ExpressiveTopBar(
                     title = if (rootGranted) stringResource(R.string.flash_title) else stringResource(R.string.flash_files_title),
-                    scrollBehavior = scrollBehavior
+                    scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             LazyColumn(
                 state = listScrollState,
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .padding(horizontal = AbkScreenHorizontalPadding),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
-                contentPadding = PaddingValues(bottom = 96.dp + outerPadding.calculateBottomPadding())
+                contentPadding = PaddingValues(top = topBarHeight + 16.dp, bottom = 96.dp + outerPadding.calculateBottomPadding())
             ) {
                 item {
                     FlashHero(

--- a/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/ModuleRepositoryScreen.kt
@@ -58,13 +58,15 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkInlineLoadingPill
 import com.abk.kernel.ui.components.rememberAbkInteractiveRefreshPresentation
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -345,12 +347,14 @@ fun ModuleRepositoryScreen(
             .height(maxHeight + childPageTopInset + childPageBottomInset)
             .offset(y = -childPageTopInset)
 
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = runtimeRepoTitleLabel(context),
                     scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled,
                     actions = {
                         IconButton(onClick = ::openRepositorySettings) {
                             Icon(
@@ -361,9 +365,9 @@ fun ModuleRepositoryScreen(
                     }
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             RuntimeModuleRepositoryListContent(
-                padding = padding,
+                topBarHeight = topBarHeight,
                 modules = filteredModules,
                 totalModules = mergedModules.size,
                 computing = listComputing,
@@ -423,7 +427,8 @@ fun ModuleRepositoryScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -432,12 +437,13 @@ fun ModuleRepositoryScreen(
                                 IconButton(onClick = childPageBack::requestDismiss) {
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.module_repo_back))
                                 }
-                            }
+                            },
+                            enableBlur = state.blurEnabled
                         )
                     }
-                ) { padding ->
+                ) { topBarHeight ->
                     RuntimeModuleRepositorySettingsPage(
-                        padding = padding,
+                        topBarHeight = topBarHeight,
                         repositories = state.runtimeModuleRepositories,
                         refreshingRepositoryIds = state.refreshingRuntimeModuleRepositoryIds,
                         onAddRepository = vm::addRuntimeModuleRepository,
@@ -809,12 +815,14 @@ private fun BuildModuleRepositoryScreenContent(
             .height(maxHeight + childPageTopInset + childPageBottomInset)
             .offset(y = -childPageTopInset)
 
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = buildRepoTitleLabel(context),
                     scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled,
                     actions = {
                         IconButton(onClick = ::openRepositorySettings) {
                             Icon(Icons.Default.Dns, contentDescription = buildRepoManageLabel(context))
@@ -822,9 +830,9 @@ private fun BuildModuleRepositoryScreenContent(
                     }
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             BuildModuleRepositoryListContent(
-                padding = padding,
+                topBarHeight = topBarHeight,
                 modules = filteredModules,
                 totalModules = mergedModules.size,
                 computing = listComputing,
@@ -892,7 +900,8 @@ private fun BuildModuleRepositoryScreenContent(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -901,12 +910,13 @@ private fun BuildModuleRepositoryScreenContent(
                                 IconButton(onClick = childPageBack::requestDismiss) {
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.module_repo_back))
                                 }
-                            }
+                            },
+                            enableBlur = state.blurEnabled
                         )
                     }
-                ) { padding ->
+                ) { topBarHeight ->
                     BuildModuleRepositorySettingsPage(
-                        padding = padding,
+                        topBarHeight = topBarHeight,
                         repositories = state.buildModuleRepositories,
                         refreshingRepositoryIds = state.refreshingBuildModuleRepositoryIds,
                         onAddRepository = vm::addBuildModuleRepository,
@@ -922,7 +932,7 @@ private fun BuildModuleRepositoryScreenContent(
 
 @Composable
 private fun RuntimeModuleRepositoryListContent(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     modules: List<MergedRuntimeCatalogModule>,
     totalModules: Int,
     computing: Boolean,
@@ -939,12 +949,11 @@ private fun RuntimeModuleRepositoryListContent(
     val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
     LazyColumn(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(10.dp),
-        contentPadding = PaddingValues(bottom = bottomPadding + 24.dp)
+        contentPadding = PaddingValues(top = topBarHeight + 16.dp, bottom = bottomPadding + 24.dp)
     ) {
         item(key = "search") {
             CompactModuleSearchField(
@@ -1047,11 +1056,14 @@ private fun RuntimeModuleRepositoryListItem(
 ) {
     val context = LocalContext.current
     val module = merged.module
+    val shape = RoundedCornerShape(8.dp)
     Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
@@ -1265,7 +1277,7 @@ private fun ModuleTagChip(
 
 @Composable
 private fun RuntimeModuleRepositorySettingsPage(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     repositories: List<RuntimeModuleRepository>,
     refreshingRepositoryIds: Set<String>,
     onAddRepository: (String) -> Unit,
@@ -1279,12 +1291,12 @@ private fun RuntimeModuleRepositorySettingsPage(
     var repositoryUrl by rememberSaveable { mutableStateOf("") }
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         ExpressiveSectionCard(
             title = runtimeRepoCentralLabel(LocalContext.current),
             subtitle = runtimeRepoCentralDescLabel(LocalContext.current),
@@ -1717,7 +1729,7 @@ private fun BuildPageMergedCatalogModule.matchesQuery(query: String): Boolean {
 
 @Composable
 private fun BuildModuleRepositoryListContent(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     modules: List<BuildPageMergedCatalogModule>,
     totalModules: Int,
     computing: Boolean,
@@ -1736,12 +1748,11 @@ private fun BuildModuleRepositoryListContent(
     val showInitialLoading = computing || (refreshing && totalModules == 0 && searchQuery.isBlank())
     LazyColumn(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(10.dp),
-        contentPadding = PaddingValues(bottom = bottomPadding + 24.dp)
+        contentPadding = PaddingValues(top = topBarHeight + 16.dp, bottom = bottomPadding + 24.dp)
     ) {
         item(key = "search") {
             CompactModuleSearchField(
@@ -1807,11 +1818,14 @@ private fun BuildModuleRepositoryListContent(
                 val allStagesAdded = supportedStages.all { stage ->
                     module.repoUrl.trim().lowercase() to stage in selectedModules
                 }
+                val shape = RoundedCornerShape(8.dp)
                 Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .blurredCardBackground(shape),
+                    shape = shape,
                     colors = CardDefaults.cardColors(
-                        containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+                        containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                 ) {
@@ -1926,7 +1940,7 @@ private fun BuildModuleRepositoryListContent(
 
 @Composable
 private fun BuildModuleRepositorySettingsPage(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     repositories: List<ModuleCatalogRepository>,
     refreshingRepositoryIds: Set<String>,
     onAddRepository: (String) -> Unit,
@@ -1941,12 +1955,12 @@ private fun BuildModuleRepositorySettingsPage(
     var repositoryUrl by rememberSaveable { mutableStateOf("") }
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         ExpressiveSectionCard(
             title = buildRepoCentralLabel(context),
             subtitle = buildRepoCentralDescLabel(context),

--- a/app/src/main/java/com/abk/kernel/ui/screens/RootAuthorizationScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/RootAuthorizationScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -87,6 +86,9 @@ import coil.compose.AsyncImage
 import com.abk.kernel.R
 import com.abk.kernel.data.model.RootGrantApp
 import com.abk.kernel.data.model.RootGrantProfile
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkCenteredLoadingTransition
 import com.abk.kernel.ui.components.AbkInlineLoadingPill
 import com.abk.kernel.ui.components.AbkLoadingPill
@@ -186,12 +188,14 @@ fun RootAuthorizationScreen(
             .height(maxHeight + childPageTopInset + childPageBottomInset)
             .offset(y = -childPageTopInset)
 
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = stringResource(R.string.root_auth_title),
                     scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled,
                     actions = {
                         IconButton(
                             onClick = {
@@ -209,10 +213,10 @@ fun RootAuthorizationScreen(
                     }
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             if (showInitialLoading) {
                 RootGrantInitialLoadingScreen(
-                    padding = padding,
+                    topBarHeight = topBarHeight,
                     outerPadding = outerPadding,
                     query = query,
                     onQueryChange = { query = it },
@@ -220,17 +224,17 @@ fun RootAuthorizationScreen(
                     onShowSystemAppsChange = { showSystemApps = it },
                     modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                 )
-                return@Scaffold
+                return@BlurScreenScaffold
             }
 
             Column(
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .padding(horizontal = AbkScreenHorizontalPadding),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
+                Spacer(Modifier.height(topBarHeight + 16.dp))
                 RootGrantSearchField(
                     query = query,
                     onQueryChange = { query = it }
@@ -344,7 +348,8 @@ fun RootAuthorizationScreen(
                         backgroundUri = state.customBackgroundUri,
                         backgroundImageEnabled = state.backgroundImageEnabled
                     )
-                    Scaffold(
+                    BlurScreenScaffold(
+                        blurConfig = state.blurConfig,
                         containerColor = Color.Transparent,
                         topBar = {
                             ExpressiveTopBar(
@@ -356,15 +361,16 @@ fun RootAuthorizationScreen(
                                     ) {
                                         Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.root_auth_back_to_list))
                                     }
-                                }
+                                },
+                                enableBlur = state.blurEnabled
                             )
                         }
-                    ) { padding ->
+                    ) { topBarHeight ->
                         when {
-                            state.rootGrantDetailLoading -> RootGrantDetailLoadingPage(padding = padding)
+                            state.rootGrantDetailLoading -> RootGrantDetailLoadingPage(topBarHeight = topBarHeight)
                             selectedDetailApp != null -> RootGrantProfilePage(
                                 app = selectedDetailApp,
-                                padding = padding,
+                                topBarHeight = topBarHeight,
                                 saving = state.rootGrantSavingPackage == selectedDetailApp.packageName,
                                 warning = state.rootGrantDetailWarning,
                                 onSave = { profile ->
@@ -372,7 +378,7 @@ fun RootAuthorizationScreen(
                                 }
                             )
                             else -> RootGrantDetailMessagePage(
-                                padding = padding,
+                                topBarHeight = topBarHeight,
                                 message = state.rootGrantError ?: stringResource(R.string.runtime_manager_inactive)
                             )
                         }
@@ -385,7 +391,7 @@ fun RootAuthorizationScreen(
 
 @Composable
 private fun RootGrantInitialLoadingScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     outerPadding: PaddingValues,
     query: String,
     onQueryChange: (String) -> Unit,
@@ -395,11 +401,10 @@ private fun RootGrantInitialLoadingScreen(
 ) {
     Column(
         modifier = modifier
-            .padding(padding)
             .fillMaxSize()
             .padding(
                 start = AbkScreenHorizontalPadding,
-                top = 0.dp,
+                top = topBarHeight + 16.dp,
                 end = AbkScreenHorizontalPadding,
                 bottom = 80.dp + outerPadding.calculateBottomPadding()
             ),
@@ -484,27 +489,27 @@ private fun RootGrantRefreshingRow(
 
 @Composable
 private fun RootGrantDetailLoadingPage(
-    padding: PaddingValues
+    topBarHeight: Dp
 ) {
     AbkCenteredLoadingTransition(
         text = stringResource(R.string.loading),
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .padding(horizontal = AbkScreenHorizontalPadding)
+            .padding(top = topBarHeight + 16.dp)
     )
 }
 
 @Composable
 private fun RootGrantDetailMessagePage(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     message: String
 ) {
     Box(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
-            .padding(horizontal = AbkScreenHorizontalPadding),
+            .padding(horizontal = AbkScreenHorizontalPadding)
+            .padding(top = topBarHeight + 16.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -534,11 +539,14 @@ private fun RootGrantAppCard(
     onToggle: (Boolean) -> Unit,
     onOpen: () -> Unit
 ) {
+    val shape = RoundedCornerShape(8.dp)
     Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         onClick = onOpen
@@ -659,7 +667,7 @@ private fun AppIcon(
 @Composable
 private fun RootGrantProfilePage(
     app: RootGrantApp,
-    padding: androidx.compose.foundation.layout.PaddingValues,
+    topBarHeight: Dp,
     saving: Boolean,
     warning: String?,
     onSave: (RootGrantProfile) -> Unit
@@ -701,12 +709,12 @@ private fun RootGrantProfilePage(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         if (!warning.isNullOrBlank()) {
             ExpressiveSectionCard(
                 title = stringResource(R.string.root_auth_profile_read_disabled_title),
@@ -897,11 +905,14 @@ private fun RootGrantChip(label: String) {
 
 @Composable
 private fun RootGrantMessageCard(message: String, onRefresh: () -> Unit) {
+    val shape = RoundedCornerShape(8.dp)
     Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.errorContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.errorContainer)
         )
     ) {
         Column(

--- a/app/src/main/java/com/abk/kernel/ui/screens/RuntimeScreens.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/RuntimeScreens.kt
@@ -72,6 +72,9 @@ import com.abk.kernel.data.model.AbkRuntimeBuildInfo
 import com.abk.kernel.data.model.AbkRuntimeModule
 import com.abk.kernel.data.model.AbkRuntimeStatus
 import com.abk.kernel.data.model.downloadFileName
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AbkInlineLoadingPill
 import com.abk.kernel.ui.components.ObserveChildPageVisibility
@@ -163,13 +166,15 @@ fun RuntimeHomeScreen(
             .fillMaxWidth()
             .height(maxHeight + childPageBottomInset)
 
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = "AnyBase Kernel",
                     compactTitle = true,
                     scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled,
                     actions = {
                         IconButton(onClick = {
                             refreshPresentation.beginRefresh()
@@ -183,16 +188,16 @@ fun RuntimeHomeScreen(
                     }
                 )
             }
-        ) { padding ->
+        ) { topBarHeight ->
             Column(
                 modifier = Modifier
-                    .padding(padding)
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = AbkScreenHorizontalPadding),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
+                Spacer(Modifier.height(topBarHeight + 16.dp))
                 RuntimeStatusHeader(
                     runtimeStatus = state.abkRuntimeStatus,
                     hasNativeManagerPermission = state.hasNativeManagerPermission,
@@ -261,6 +266,8 @@ fun RuntimeHomeScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled,
                     downloadDirectory = state.downloadDirectory,
+                    blurEnabled = state.blurEnabled,
+                    blurBackgroundExpEnabled = state.blurBackgroundExpEnabled,
                     onBack = childPageBack::requestDismiss,
                     onBackEnabledChange = { managerPatchBackEnabled = it }
                 )
@@ -508,45 +515,36 @@ fun InstalledModulesScreen(
         if (state.runtimeNavigationEnabled) vm.refreshAbkRuntimeStatus()
     }
 
-    Scaffold(
-        containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
-        topBar = {
-            ExpressiveTopBar(
-                title = stringResource(R.string.runtime_installed_modules_title),
-                scrollBehavior = scrollBehavior,
-                actions = {
-                    IconButton(onClick = {
-                        refreshPresentation.beginRefresh()
-                        vm.refreshAbkRuntimeStatus()
-                    }) {
-                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.runtime_refresh_installed_modules))
+    Box(Modifier.fillMaxSize()) {
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
+            containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
+            topBar = {
+                ExpressiveTopBar(
+                    title = stringResource(R.string.runtime_installed_modules_title),
+                    scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled,
+                    actions = {
+                        IconButton(onClick = {
+                            refreshPresentation.beginRefresh()
+                            vm.refreshAbkRuntimeStatus()
+                        }) {
+                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.runtime_refresh_installed_modules))
+                        }
                     }
-                }
-            )
-        },
-        floatingActionButton = {
-            SmallFloatingActionButton(
-                onClick = {
-                    launchModulePickerWithPermissionCheck()
-                },
-                modifier = Modifier.padding(bottom = outerPadding.calculateBottomPadding()),
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-            ) {
-                Icon(Icons.Default.UploadFile, contentDescription = stringResource(R.string.runtime_install_module))
+                )
             }
-        }
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .fillMaxSize()
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = AbkScreenHorizontalPadding),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            RuntimeModuleSearchField(query, onValueChange = { query = it })
+        ) { topBarHeight ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(scrollBehavior.nestedScrollConnection)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = AbkScreenHorizontalPadding),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Spacer(Modifier.height(topBarHeight + 16.dp))
+                RuntimeModuleSearchField(query, onValueChange = { query = it })
 
             when {
                 showInitialLoading -> {
@@ -636,6 +634,20 @@ fun InstalledModulesScreen(
             }
 
             Spacer(Modifier.height(80.dp + outerPadding.calculateBottomPadding()))
+        }
+        }
+        SmallFloatingActionButton(
+            onClick = {
+                launchModulePickerWithPermissionCheck()
+            },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .navigationBarsPadding()
+                .padding(end = 16.dp, bottom = 16.dp + outerPadding.calculateBottomPadding()),
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        ) {
+            Icon(Icons.Default.UploadFile, contentDescription = stringResource(R.string.runtime_install_module))
         }
     }
 
@@ -936,11 +948,14 @@ private fun RuntimeErrorCard(
     message: String,
     onRefresh: () -> Unit
 ) {
+    val shape = RoundedCornerShape(8.dp)
     ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.elevatedCardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.errorContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.errorContainer)
         )
     ) {
         Column(
@@ -984,11 +999,14 @@ private fun InstalledRuntimeModuleCard(
     onOpenWebUi: () -> Unit
 ) {
     val canUninstall = module.canUninstallRuntimeModule()
+    val shape = RoundedCornerShape(8.dp)
     Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -15,8 +15,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -61,7 +63,6 @@ import com.abk.kernel.utils.DownloadDirectoryUtils
 import com.abk.kernel.utils.DownloadUtils
 import com.abk.kernel.utils.LocaleHelper
 import com.abk.kernel.ui.blur.BlurScreenScaffold
-import com.abk.kernel.ui.blur.isBlurCapableDevice
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AbkSegmentedButtonOption
 import com.abk.kernel.ui.components.AbkSingleChoiceSegmentedButtonRow
@@ -2064,30 +2065,35 @@ private fun ThemeSettingsScreen(
         }
 
         SettingsGroup(title = stringResource(R.string.settings_blur)) {
-            // Real frosted-glass top/bottom bars need AGSL runtime shaders (API 33+);
-            // on older devices that toggle is hidden and the bars keep their opaque
-            // fallback.
-            if (isBlurCapableDevice()) {
+            // Master blur switch controls every blur surface (AGSL bars on API 33+ and
+            // the software card blur on every API level), so it is shown on all devices.
+            // On API 26-32 the bars keep their opaque fallback while the card path below
+            // still works.
+            ExpressiveSwitchItem(
+                title = stringResource(R.string.settings_blur),
+                subtitle = stringResource(R.string.settings_blur_desc),
+                icon = Icons.Default.BlurOn,
+                checked = blurEnabled,
+                onCheckedChange = onBlurEnabledChange
+            )
+            // The nested "render custom background into blur" item expands out from below
+            // the toggle when blur is enabled. It is a no-op until a custom background
+            // image is configured, so it is disabled until then.
+            AnimatedVisibility(
+                visible = blurEnabled,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically()
+            ) {
+                val backgroundConfigured = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
                 ExpressiveSwitchItem(
-                    title = stringResource(R.string.settings_blur),
-                    subtitle = stringResource(R.string.settings_blur_desc),
-                    icon = Icons.Default.BlurOn,
-                    checked = blurEnabled,
-                    onCheckedChange = onBlurEnabledChange
+                    title = stringResource(R.string.settings_blur_background),
+                    subtitle = stringResource(R.string.settings_blur_background_desc),
+                    icon = Icons.Default.Image,
+                    checked = blurBackgroundExpEnabled,
+                    enabled = backgroundConfigured,
+                    onCheckedChange = onBlurBackgroundExpEnabledChange
                 )
             }
-            // The software StackBlur card path works on every API level, so its toggle
-            // is exposed regardless of runtime-shader support. It is a no-op until a
-            // custom background image is configured, so it is disabled until then.
-            val backgroundConfigured = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
-            ExpressiveSwitchItem(
-                title = stringResource(R.string.settings_blur_background),
-                subtitle = stringResource(R.string.settings_blur_background_desc),
-                icon = Icons.Default.Image,
-                checked = blurBackgroundExpEnabled,
-                enabled = backgroundConfigured,
-                onCheckedChange = onBlurBackgroundExpEnabledChange
-            )
         }
 
         SettingsGroup(title = stringResource(R.string.settings_color_source)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -2065,38 +2065,6 @@ private fun ThemeSettingsScreen(
             }
         }
 
-        SettingsGroup(title = stringResource(R.string.settings_blur)) {
-            // Master blur switch controls every blur surface (AGSL bars on API 33+ and
-            // the software card blur on every API level), so it is shown on all devices.
-            // On API 26-32 the bars keep their opaque fallback while the card path below
-            // still works.
-            ExpressiveSwitchItem(
-                title = stringResource(R.string.settings_blur),
-                subtitle = stringResource(R.string.settings_blur_desc),
-                icon = Icons.Default.BlurOn,
-                checked = blurEnabled,
-                onCheckedChange = onBlurEnabledChange
-            )
-            // The nested "render custom background into blur" item expands out from below
-            // the toggle when blur is enabled. It is a no-op until a custom background
-            // image is configured, so it is disabled until then.
-            AnimatedVisibility(
-                visible = blurEnabled,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
-            ) {
-                val backgroundConfigured = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
-                ExpressiveSwitchItem(
-                    title = stringResource(R.string.settings_blur_background),
-                    subtitle = stringResource(R.string.settings_blur_background_desc),
-                    icon = Icons.Default.Image,
-                    checked = blurBackgroundExpEnabled,
-                    enabled = backgroundConfigured,
-                    onCheckedChange = onBlurBackgroundExpEnabledChange
-                )
-            }
-        }
-
         SettingsGroup(title = stringResource(R.string.settings_color_source)) {
             SwitchSettingsItem(
                 icon = Icons.Default.AutoAwesome,
@@ -2172,6 +2140,45 @@ private fun ThemeSettingsScreen(
                     leadingIcon = Icons.Default.Delete,
                     onClick = { onBackgroundImageChange(null) }
                 )
+            }
+            // Blur controls (merged in from the former "模糊" card): they pop out above the
+            // opacity slider once a custom background is configured, reusing the original
+            // expand/fade animation. The master switch controls every blur surface (AGSL
+            // bars on API 33+ and the software card blur on every API level); the nested
+            // "render custom background into blur" item expands out from below the toggle
+            // when blur is enabled.
+            val backgroundConfigured = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+            AnimatedVisibility(
+                visible = backgroundConfigured,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically()
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    ExpressiveSwitchItem(
+                        title = stringResource(R.string.settings_blur),
+                        subtitle = stringResource(R.string.settings_blur_desc),
+                        icon = Icons.Default.BlurOn,
+                        checked = blurEnabled,
+                        onCheckedChange = onBlurEnabledChange
+                    )
+                    AnimatedVisibility(
+                        visible = blurEnabled,
+                        enter = fadeIn() + expandVertically(),
+                        exit = fadeOut() + shrinkVertically()
+                    ) {
+                        ExpressiveSwitchItem(
+                            title = stringResource(R.string.settings_blur_background),
+                            subtitle = stringResource(R.string.settings_blur_background_desc),
+                            icon = Icons.Default.Image,
+                            checked = blurBackgroundExpEnabled,
+                            enabled = backgroundConfigured,
+                            onCheckedChange = onBlurBackgroundExpEnabledChange
+                        )
+                    }
+                }
             }
             BackgroundAlphaControl(
                 alpha = uiSurfaceAlpha,

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -15,10 +15,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -428,7 +426,8 @@ fun SettingsScreen(
                         onUiSurfaceAlphaChange = { alpha -> vm.setUiSurfaceAlpha(alpha) },
                         onUiSurfaceAlphaPreviewChange = { alpha -> vm.setUiSurfaceAlphaPreview(alpha) },
                         onBlurEnabledChange = vm::setBlurEnabled,
-                        onBlurBackgroundExpEnabledChange = vm::setBlurBackgroundExpEnabled
+                        onBlurBackgroundExpEnabledChange = vm::setBlurBackgroundExpEnabled,
+                        onUiSurfaceAlphaSync = vm::syncUiSurfaceAlphaPreview
                     )
                 }
             }
@@ -2004,8 +2003,16 @@ private fun ThemeSettingsScreen(
     onUiSurfaceAlphaChange: (Float) -> Unit,
     onUiSurfaceAlphaPreviewChange: (Float) -> Unit,
     onBlurEnabledChange: (Boolean) -> Unit,
-    onBlurBackgroundExpEnabledChange: (Boolean) -> Unit
+    onBlurBackgroundExpEnabledChange: (Boolean) -> Unit,
+    onUiSurfaceAlphaSync: () -> Unit
 ) {
+    // An interrupted slider drag (back gesture / backgrounding / the slider being
+    // disabled mid-drag) never fires onValueChangeFinished, so the in-memory preview
+    // would stay stuck on an un-persisted alpha for the whole session. Restore it from
+    // prefs when the settings page goes away.
+    DisposableEffect(Unit) {
+        onDispose(onUiSurfaceAlphaSync)
+    }
     val context = LocalContext.current
     val dynamicColorAvailable = isDynamicColorAvailable()
     val effectiveDynamicColorEnabled = dynamicColorAvailable && dynamicColorEnabled
@@ -2056,10 +2063,11 @@ private fun ThemeSettingsScreen(
             }
         }
 
-        // Real frosted-glass needs runtime shaders (API 33+); on older devices the
-        // settings are hidden entirely and the UI keeps its opaque fallback.
-        if (isBlurCapableDevice()) {
-            SettingsGroup(title = stringResource(R.string.settings_blur)) {
+        SettingsGroup(title = stringResource(R.string.settings_blur)) {
+            // Real frosted-glass top/bottom bars need AGSL runtime shaders (API 33+);
+            // on older devices that toggle is hidden and the bars keep their opaque
+            // fallback.
+            if (isBlurCapableDevice()) {
                 ExpressiveSwitchItem(
                     title = stringResource(R.string.settings_blur),
                     subtitle = stringResource(R.string.settings_blur_desc),
@@ -2067,22 +2075,19 @@ private fun ThemeSettingsScreen(
                     checked = blurEnabled,
                     onCheckedChange = onBlurEnabledChange
                 )
-                // The nested "render custom background into blur" item expands out
-                // from below the toggle when blur is enabled.
-                AnimatedVisibility(
-                    visible = blurEnabled,
-                    enter = fadeIn() + expandVertically(),
-                    exit = fadeOut() + shrinkVertically()
-                ) {
-                    ExpressiveSwitchItem(
-                        title = stringResource(R.string.settings_blur_background),
-                        subtitle = stringResource(R.string.settings_blur_background_desc),
-                        icon = Icons.Default.Image,
-                        checked = blurBackgroundExpEnabled,
-                        onCheckedChange = onBlurBackgroundExpEnabledChange
-                    )
-                }
             }
+            // The software StackBlur card path works on every API level, so its toggle
+            // is exposed regardless of runtime-shader support. It is a no-op until a
+            // custom background image is configured, so it is disabled until then.
+            val backgroundConfigured = backgroundImageEnabled && !backgroundUri.isNullOrBlank()
+            ExpressiveSwitchItem(
+                title = stringResource(R.string.settings_blur_background),
+                subtitle = stringResource(R.string.settings_blur_background_desc),
+                icon = Icons.Default.Image,
+                checked = blurBackgroundExpEnabled,
+                enabled = backgroundConfigured,
+                onCheckedChange = onBlurBackgroundExpEnabledChange
+            )
         }
 
         SettingsGroup(title = stringResource(R.string.settings_color_source)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -15,8 +15,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -50,6 +52,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
 import coil.compose.AsyncImage
@@ -59,6 +62,8 @@ import com.abk.kernel.extensions.AbkExtensionManagerScreen
 import com.abk.kernel.utils.DownloadDirectoryUtils
 import com.abk.kernel.utils.DownloadUtils
 import com.abk.kernel.utils.LocaleHelper
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.isBlurCapableDevice
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.AbkSegmentedButtonOption
 import com.abk.kernel.ui.components.AbkSingleChoiceSegmentedButtonRow
@@ -325,17 +330,19 @@ fun SettingsScreen(
             .fillMaxWidth()
             .height(maxHeight + childPageTopInset + childPageBottomInset)
             .offset(y = -childPageTopInset)
-        Scaffold(
+        BlurScreenScaffold(
+            blurConfig = state.blurConfig,
             containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
             topBar = {
                 ExpressiveTopBar(
                     title = stringResource(R.string.settings_title),
-                    scrollBehavior = scrollBehavior
+                    scrollBehavior = scrollBehavior,
+                    enableBlur = state.blurEnabled
                 )
             }
-        ) {
+        ) { topBarHeight ->
             SettingsMainContent(
-                padding = it,
+                topBarHeight = topBarHeight,
                 outerPadding = outerPadding,
                 state = state,
                 vm = vm,
@@ -383,7 +390,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -392,12 +400,13 @@ fun SettingsScreen(
                                 IconButton(onClick = childPageBack::requestDismiss) {
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
-                            }
+                            },
+                            enableBlur = state.blurEnabled
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     ThemeSettingsScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         themeMode = state.themeMode,
                         dynamicColorEnabled = state.dynamicColorEnabled,
                         customThemeColorArgb = state.customThemeColorArgb,
@@ -405,6 +414,8 @@ fun SettingsScreen(
                         backgroundUri = state.customBackgroundUri,
                         backgroundImageEnabled = state.backgroundImageEnabled,
                         uiSurfaceAlpha = state.uiSurfaceAlpha,
+                        blurEnabled = state.blurEnabled,
+                        blurBackgroundExpEnabled = state.blurBackgroundExpEnabled,
                         onThemeModeChange = { value -> vm.setThemeMode(value) },
                         onDynamicColorEnabledChange = { enabled, themeColor, accentColor ->
                             vm.setDynamicColorEnabled(enabled, themeColor, accentColor)
@@ -414,7 +425,10 @@ fun SettingsScreen(
                         },
                         onBackgroundImageChange = { uri -> vm.setBackgroundImageUri(uri) },
                         onBackgroundImageEnabledChange = { enabled -> vm.setBackgroundImageEnabled(enabled) },
-                        onUiSurfaceAlphaChange = { alpha -> vm.setUiSurfaceAlpha(alpha) }
+                        onUiSurfaceAlphaChange = { alpha -> vm.setUiSurfaceAlpha(alpha) },
+                        onUiSurfaceAlphaPreviewChange = { alpha -> vm.setUiSurfaceAlphaPreview(alpha) },
+                        onBlurEnabledChange = vm::setBlurEnabled,
+                        onBlurBackgroundExpEnabledChange = vm::setBlurBackgroundExpEnabled
                     )
                 }
             }
@@ -436,7 +450,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -446,6 +461,7 @@ fun SettingsScreen(
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
                             },
+                            enableBlur = state.blurEnabled,
                             actions = {
                                 IconButton(onClick = {
                                     refreshPresentation.beginRefresh()
@@ -456,9 +472,9 @@ fun SettingsScreen(
                             }
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     AppProfileTemplateSettingsScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         state = state,
                         showRefreshLoading = refreshPresentation.showLoading && state.appProfileTemplates.isNotEmpty(),
                         onRefresh = {
@@ -494,6 +510,10 @@ fun SettingsScreen(
                     onBack = childPageBack::requestDismiss,
                     modifier = Modifier.fillMaxSize(),
                     containerColor = Color.Transparent,
+                    blurEnabled = state.blurEnabled,
+                    blurBackgroundExpEnabled = state.blurBackgroundExpEnabled,
+                    backgroundUri = state.customBackgroundUri,
+                    backgroundImageEnabled = state.backgroundImageEnabled,
                 )
             }
         }
@@ -514,7 +534,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -524,6 +545,7 @@ fun SettingsScreen(
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
                             },
+                            enableBlur = state.blurEnabled,
                             actions = {
                                 IconButton(onClick = {
                                     refreshPresentation.beginRefresh()
@@ -534,9 +556,9 @@ fun SettingsScreen(
                             }
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     ManagerToolsSettingsScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         state = state,
                         showRefreshLoading = refreshPresentation.showLoading,
                         onSelinuxChange = vm::setSelinuxEnforcing,
@@ -563,7 +585,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -573,6 +596,7 @@ fun SettingsScreen(
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
                             },
+                            enableBlur = state.blurEnabled,
                             actions = {
                                 IconButton(onClick = {
                                     refreshPresentation.beginRefresh()
@@ -583,9 +607,9 @@ fun SettingsScreen(
                             }
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     KernelCapabilitiesSettingsScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         state = state,
                         showRefreshLoading = refreshPresentation.showLoading,
                         onRefresh = {
@@ -614,7 +638,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -634,9 +659,9 @@ fun SettingsScreen(
                             }
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     SusfsControlScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         state = state,
                         showRefreshLoading = refreshPresentation.showLoading,
                         onApply = vm::applySusfsConfig,
@@ -665,7 +690,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -674,12 +700,13 @@ fun SettingsScreen(
                                 IconButton(onClick = childPageBack::requestDismiss) {
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
-                            }
+                            },
+                            enableBlur = state.blurEnabled
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     AboutRepositoryScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         onOpenUrl = { openUrl(context, it) },
                         onOpenSourceLicenses = ::openOpenSourceLicenses
                     )
@@ -702,7 +729,8 @@ fun SettingsScreen(
                     backgroundUri = state.customBackgroundUri,
                     backgroundImageEnabled = state.backgroundImageEnabled
                 )
-                Scaffold(
+                BlurScreenScaffold(
+                    blurConfig = state.blurConfig,
                     containerColor = Color.Transparent,
                     topBar = {
                         ExpressiveTopBar(
@@ -711,12 +739,13 @@ fun SettingsScreen(
                                 IconButton(onClick = childPageBack::requestDismiss) {
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
-                            }
+                            },
+                            enableBlur = state.blurEnabled
                         )
                     }
-                ) {
+                ) { topBarHeight ->
                     OpenSourceLicensesScreen(
-                        padding = it,
+                        topBarHeight = topBarHeight,
                         onOpenUrl = { openUrl(context, it) }
                     )
                 }
@@ -738,7 +767,7 @@ private fun SettingsPageBackground(
 
 @Composable
 private fun SettingsMainContent(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     outerPadding: PaddingValues,
     state: MainUiState,
     vm: MainViewModel,
@@ -759,13 +788,13 @@ private fun SettingsMainContent(
     val context = LocalContext.current
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         SettingsGroup(title = stringResource(R.string.settings_account)) {
             state.user?.let { user ->
                 ExpressiveListItem(
@@ -1398,7 +1427,7 @@ private enum class SecurityKeyImportTarget {
 
 @Composable
 private fun KernelCapabilitiesSettingsScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     state: MainUiState,
     showRefreshLoading: Boolean,
     onRefresh: () -> Unit,
@@ -1409,12 +1438,12 @@ private fun KernelCapabilitiesSettingsScreen(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         Crossfade(targetState = showRefreshLoading || showInitialLoading, label = "kernel-capabilities-refresh") { refreshing ->
             if (refreshing) {
                 AbkInlineLoadingPill(
@@ -1656,7 +1685,7 @@ private fun ManagerModeSettingItem(
 
 @Composable
 private fun ManagerToolsSettingsScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     state: MainUiState,
     showRefreshLoading: Boolean,
     onSelinuxChange: (Boolean) -> Unit,
@@ -1680,12 +1709,12 @@ private fun ManagerToolsSettingsScreen(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         Crossfade(targetState = showRefreshLoading || showInitialLoading, label = "manager-tools-refresh") { refreshing ->
             if (refreshing) {
                 AbkInlineLoadingPill(
@@ -1780,7 +1809,7 @@ private fun selinuxModeLabel(mode: String): String =
 
 @Composable
 private fun AppProfileTemplateSettingsScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     state: MainUiState,
     showRefreshLoading: Boolean,
     onRefresh: () -> Unit,
@@ -1802,12 +1831,12 @@ private fun AppProfileTemplateSettingsScreen(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         Crossfade(targetState = showRefreshLoading, label = "template-refresh") { refreshing ->
             if (refreshing) {
                 AbkInlineLoadingPill(
@@ -1957,7 +1986,7 @@ private fun defaultAppProfileTemplateJson(): String =
 
 @Composable
 private fun ThemeSettingsScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     themeMode: String,
     dynamicColorEnabled: Boolean,
     customThemeColorArgb: Int?,
@@ -1965,12 +1994,17 @@ private fun ThemeSettingsScreen(
     backgroundUri: String?,
     backgroundImageEnabled: Boolean,
     uiSurfaceAlpha: Float,
+    blurEnabled: Boolean,
+    blurBackgroundExpEnabled: Boolean,
     onThemeModeChange: (String) -> Unit,
     onDynamicColorEnabledChange: (Boolean, Int?, Int?) -> Unit,
     onCustomThemeColorsChange: (Int, Int) -> Unit,
     onBackgroundImageChange: (String?) -> Unit,
     onBackgroundImageEnabledChange: (Boolean) -> Unit,
-    onUiSurfaceAlphaChange: (Float) -> Unit
+    onUiSurfaceAlphaChange: (Float) -> Unit,
+    onUiSurfaceAlphaPreviewChange: (Float) -> Unit,
+    onBlurEnabledChange: (Boolean) -> Unit,
+    onBlurBackgroundExpEnabledChange: (Boolean) -> Unit
 ) {
     val context = LocalContext.current
     val dynamicColorAvailable = isDynamicColorAvailable()
@@ -1999,12 +2033,12 @@ private fun ThemeSettingsScreen(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = AbkScreenHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         SettingsGroup(title = stringResource(R.string.settings_appearance_mode)) {
             themes.forEach { (key, label, icon) ->
                 val selected = themeMode == key
@@ -2019,6 +2053,35 @@ private fun ThemeSettingsScreen(
                     },
                     onClick = { onThemeModeChange(key) }
                 )
+            }
+        }
+
+        // Real frosted-glass needs runtime shaders (API 33+); on older devices the
+        // settings are hidden entirely and the UI keeps its opaque fallback.
+        if (isBlurCapableDevice()) {
+            SettingsGroup(title = stringResource(R.string.settings_blur)) {
+                ExpressiveSwitchItem(
+                    title = stringResource(R.string.settings_blur),
+                    subtitle = stringResource(R.string.settings_blur_desc),
+                    icon = Icons.Default.BlurOn,
+                    checked = blurEnabled,
+                    onCheckedChange = onBlurEnabledChange
+                )
+                // The nested "render custom background into blur" item expands out
+                // from below the toggle when blur is enabled.
+                AnimatedVisibility(
+                    visible = blurEnabled,
+                    enter = fadeIn() + expandVertically(),
+                    exit = fadeOut() + shrinkVertically()
+                ) {
+                    ExpressiveSwitchItem(
+                        title = stringResource(R.string.settings_blur_background),
+                        subtitle = stringResource(R.string.settings_blur_background_desc),
+                        icon = Icons.Default.Image,
+                        checked = blurBackgroundExpEnabled,
+                        onCheckedChange = onBlurBackgroundExpEnabledChange
+                    )
+                }
             }
         }
 
@@ -2101,7 +2164,8 @@ private fun ThemeSettingsScreen(
             BackgroundAlphaControl(
                 alpha = uiSurfaceAlpha,
                 enabled = backgroundImageEnabled && !backgroundUri.isNullOrBlank(),
-                onAlphaChange = onUiSurfaceAlphaChange
+                onAlphaChange = onUiSurfaceAlphaPreviewChange,
+                onAlphaChangeFinished = onUiSurfaceAlphaChange
             )
         }
 
@@ -2113,8 +2177,13 @@ private fun ThemeSettingsScreen(
 private fun BackgroundAlphaControl(
     alpha: Float,
     enabled: Boolean,
-    onAlphaChange: (Float) -> Unit
+    onAlphaChange: (Float) -> Unit,
+    onAlphaChangeFinished: ((Float) -> Unit)? = null
 ) {
+    // Keep drag state local so every pointer tick redraws the slider and the shared
+    // surface-alpha CompositionLocal without recomposing this entire settings page.
+    // Persistence remains deferred until the gesture finishes.
+    var previewAlpha by remember(alpha) { mutableFloatStateOf(alpha.coerceIn(0f, 1f)) }
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(6.dp)
@@ -2131,14 +2200,20 @@ private fun BackgroundAlphaControl(
                 color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
             )
             Text(
-                text = "${(alpha.coerceIn(0f, 1f) * 100).toInt()}%",
+                text = "${(previewAlpha * 100).toInt()}%",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
         Slider(
-            value = alpha.coerceIn(0f, 1f),
-            onValueChange = onAlphaChange,
+            value = previewAlpha,
+            onValueChange = {
+                previewAlpha = it
+                onAlphaChange(it)
+            },
+            onValueChangeFinished = {
+                onAlphaChangeFinished?.invoke(previewAlpha)
+            },
             valueRange = 0f..1f,
             enabled = enabled
         )
@@ -2281,18 +2356,19 @@ private fun isDynamicColorAvailable(): Boolean =
 
 @Composable
 private fun AboutRepositoryScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     onOpenUrl: (String) -> Unit,
     onOpenSourceLicenses: () -> Unit
 ) {
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = AbkScreenHorizontalPadding, vertical = 12.dp),
+            .padding(horizontal = AbkScreenHorizontalPadding)
+            .padding(bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         ExpressiveHeroCard(
             title = stringResource(R.string.app_full_name),
             subtitle = stringResource(R.string.settings_about_intro),
@@ -2341,17 +2417,18 @@ private fun AboutRepositoryScreen(
 
 @Composable
 private fun OpenSourceLicensesScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     onOpenUrl: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
-            .padding(padding)
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = AbkScreenHorizontalPadding, vertical = 12.dp),
+            .padding(horizontal = AbkScreenHorizontalPadding)
+            .padding(bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         ExpressiveHeroCard(
             title = stringResource(R.string.settings_open_source_licenses),
             subtitle = stringResource(R.string.settings_open_source_licenses_intro),

--- a/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SettingsScreen.kt
@@ -649,6 +649,7 @@ fun SettingsScreen(
                                     Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_back))
                                 }
                             },
+                            enableBlur = state.blurEnabled,
                             actions = {
                                 IconButton(onClick = {
                                     refreshPresentation.beginRefresh()

--- a/app/src/main/java/com/abk/kernel/ui/screens/StatusScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/StatusScreen.kt
@@ -29,6 +29,9 @@ import com.abk.kernel.BuildConfig
 import com.abk.kernel.R
 import com.abk.kernel.data.model.BuildStatus
 import com.abk.kernel.data.model.WorkflowRun
+import com.abk.kernel.ui.blur.BlurScreenScaffold
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.AbkScreenHorizontalPadding
 import com.abk.kernel.ui.components.ExpressiveHeroCard
 import com.abk.kernel.ui.components.ExpressiveSectionCard
@@ -54,13 +57,15 @@ fun StatusScreen(
 
     LaunchedEffect(Unit) { vm.loadRecentRuns() }
 
-    Scaffold(
+    BlurScreenScaffold(
+        blurConfig = state.blurConfig,
         containerColor = appPageBackgroundColor(uiSurfaceColor(MaterialTheme.colorScheme.surface)),
         topBar = {
             ExpressiveTopBar(
                 title = stringResource(R.string.app_name),
                 compactTitle = true,
                 scrollBehavior = scrollBehavior,
+                enableBlur = state.blurEnabled,
                 actions = {
                     IconButton(onClick = onToggleRuntimeNavigation) {
                         Icon(
@@ -75,16 +80,16 @@ fun StatusScreen(
                 }
             )
         }
-    ) { padding ->
+    ) { topBarHeight ->
         Column(
             modifier = Modifier
-                .padding(padding)
                 .fillMaxSize()
                 .nestedScroll(scrollBehavior.nestedScrollConnection)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = AbkScreenHorizontalPadding),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            Spacer(Modifier.height(topBarHeight + 16.dp))
             val ksuVersion = remember(state.rootGranted) {
                 if (state.rootGranted) RootUtils.getKsuVersion() else "N/A"
             }
@@ -546,9 +551,13 @@ private fun StatusMetricCard(
         animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
         label = "metric-color"
     )
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)),
+        modifier = modifier.blurredCardBackground(shape = shape, enabled = true),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/SusfsControlScreen.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/SusfsControlScreen.kt
@@ -4,7 +4,6 @@ package com.abk.kernel.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.abk.kernel.R
 import com.abk.kernel.data.model.SusfsConfig
@@ -65,7 +65,7 @@ import com.abk.kernel.viewmodel.MainUiState
 
 @Composable
 internal fun SusfsControlScreen(
-    padding: PaddingValues,
+    topBarHeight: Dp,
     state: MainUiState,
     showRefreshLoading: Boolean,
     onApply: (SusfsConfig) -> Unit,
@@ -187,11 +187,11 @@ internal fun SusfsControlScreen(
 
     Column(
         modifier = Modifier
-            .padding(padding)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        Spacer(Modifier.height(topBarHeight + 16.dp))
         if (showRefreshLoading) {
             AbkInlineLoadingPill(
                 text = stringResource(R.string.settings_manager_loading_title),

--- a/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashArtifacts.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashArtifacts.kt
@@ -206,6 +206,8 @@ import com.abk.kernel.ui.components.ExpressiveEmptyState
 import com.abk.kernel.ui.components.ExpressiveHeroCard
 import com.abk.kernel.ui.components.ExpressiveSectionCard
 import com.abk.kernel.ui.components.ExpressiveStatusChip
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.ExpressiveTopBar
 import com.abk.kernel.ui.theme.uiSurfaceColor
 import com.abk.kernel.utils.DownloadUtils
@@ -252,10 +254,14 @@ internal fun ArtifactSourceCard(
         animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
         label = "artifact-download"
     )
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -361,10 +367,14 @@ internal fun LocalOnlyArtifactCard(
     onDelete: (DownloadedArtifact) -> Unit,
     allowRootActions: Boolean
 ) {
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashPrebuilt.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashPrebuilt.kt
@@ -207,6 +207,8 @@ import com.abk.kernel.ui.components.ExpressiveEmptyState
 import com.abk.kernel.ui.components.ExpressiveHeroCard
 import com.abk.kernel.ui.components.ExpressiveSectionCard
 import com.abk.kernel.ui.components.ExpressiveStatusChip
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.ExpressiveTopBar
 import com.abk.kernel.ui.theme.uiSurfaceColor
 import com.abk.kernel.utils.DownloadUtils
@@ -282,10 +284,15 @@ internal fun PrebuiltReleaseCard(
     release: PrebuiltGkiRelease,
     onClick: () -> Unit
 ) {
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape)
+            .clickable(onClick = onClick),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -497,10 +504,14 @@ internal fun PrebuiltGkiAssetCard(
         animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
         label = "prebuilt-gki-download"
     )
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashWorkflow.kt
+++ b/app/src/main/java/com/abk/kernel/ui/screens/flash/FlashWorkflow.kt
@@ -206,6 +206,8 @@ import com.abk.kernel.ui.components.MinuteHandPhase
 import com.abk.kernel.ui.components.ExpressiveEmptyState
 import com.abk.kernel.ui.components.ExpressiveHeroCard
 import com.abk.kernel.ui.components.ExpressiveSectionCard
+import com.abk.kernel.ui.blur.blurredCardBackground
+import com.abk.kernel.ui.blur.blurredCardSurfaceColor
 import com.abk.kernel.ui.components.ExpressiveStatusChip
 import com.abk.kernel.ui.components.ExpressiveTopBar
 import com.abk.kernel.ui.theme.uiSurfaceColor
@@ -258,13 +260,16 @@ internal fun WorkflowRunCard(
     val dateLabel = group.runCreatedAt.take(10)
     val colorScheme = MaterialTheme.colorScheme
     val cardContainer = when {
-        failedGhost -> uiSurfaceColor(lerp(colorScheme.surfaceContainer, colorScheme.errorContainer, 0.48f))
-        else -> uiSurfaceColor(colorScheme.surfaceContainer)
+        failedGhost -> blurredCardSurfaceColor(lerp(colorScheme.surfaceContainer, colorScheme.errorContainer, 0.48f))
+        else -> blurredCardSurfaceColor(colorScheme.surfaceContainer)
     }
+    val shape = MaterialTheme.shapes.medium
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .blurredCardBackground(shape)
             .clickable(onClick = onClick),
+        shape = shape,
         colors = CardDefaults.cardColors(containerColor = cardContainer),
         border = if (failedGhost) {
             BorderStroke(1.dp, colorScheme.error.copy(alpha = 0.28f))
@@ -466,9 +471,11 @@ internal fun BuildErrorLogPanel(text: String) {
     val logScrollState = rememberScrollState()
     val edgeLock = rememberBuildErrorLogEdgeLock(logScrollState)
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(RoundedCornerShape(12.dp)),
         shape = RoundedCornerShape(12.dp),
-        color = uiSurfaceColor(colorScheme.surfaceContainerHighest),
+        color = blurredCardSurfaceColor(colorScheme.surfaceContainerHighest),
     ) {
         SelectionContainer {
             Text(
@@ -1048,10 +1055,14 @@ internal fun parseIsoMillis(value: String): Long = runCatching {
 
 @Composable
 internal fun CategoryProgressCard(progress: BuildProgress?) {
+    val shape = MaterialTheme.shapes.medium
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .blurredCardBackground(shape),
+        shape = shape,
         colors = CardDefaults.cardColors(
-            containerColor = uiSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
+            containerColor = blurredCardSurfaceColor(MaterialTheme.colorScheme.surfaceContainer)
         )
     ) {
         Column(

--- a/app/src/main/java/com/abk/kernel/utils/BackgroundImageStorage.kt
+++ b/app/src/main/java/com/abk/kernel/utils/BackgroundImageStorage.kt
@@ -1,0 +1,77 @@
+package com.abk.kernel.utils
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Stores the user-picked custom background as a plain file in app-private storage.
+ *
+ * The picker returns a `content://` URI backed by an external provider. Decoding it on
+ * every cold start means a cross-process read (the provider process may itself be cold,
+ * and the persistable permission can be lost), which is exactly why the wallpaper can
+ * arrive late — and the screen shows the bare surface — after the app is killed and
+ * reopened. Copying once into app-private storage makes every later launch decode a
+ * local file: fast, deterministic, and independent of any provider.
+ */
+object BackgroundImageStorage {
+
+    private const val BACKGROUND_FILE_NAME = "abk_custom_background.jpg"
+    /** Upper bound on the copied background; generous for wallpapers. */
+    private const val MAX_BACKGROUND_BYTES = 64L * 1024 * 1024
+
+    fun internalFile(context: Context): File = File(context.filesDir, BACKGROUND_FILE_NAME)
+
+    /**
+     * Copies [uri] into app-private storage. Returns the `file://` Uri on success, or
+     * null when the source cannot be read (e.g. the persistable permission was lost),
+     * is not an image, or exceeds [MAX_BACKGROUND_BYTES].
+     */
+    fun copyToInternalStorage(context: Context, uri: Uri): Uri? {
+        // Only images belong here; a provider lying about type or size would otherwise
+        // waste storage and stall the picker / startup migration.
+        val type = context.contentResolver.getType(uri)
+        if (type != null && !type.startsWith("image/")) return null
+
+        val file = internalFile(context)
+        file.parentFile?.mkdirs()
+        // Unique temp so concurrent copies (user pick + startup migration) cannot
+        // interleave writes to the same file; the fully-written temp is then renamed.
+        val temp = File.createTempFile("abk_bg", ".tmp", file.parentFile)
+        try {
+            val input = context.contentResolver.openInputStream(uri) ?: return null
+            try {
+                FileOutputStream(temp).use { output ->
+                    val buffer = ByteArray(8 * 1024)
+                    var total = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > MAX_BACKGROUND_BYTES) return null
+                        output.write(buffer, 0, read)
+                    }
+                    output.flush()
+                }
+            } finally {
+                input.close()
+            }
+            if (!temp.renameTo(file)) {
+                temp.copyTo(file, overwrite = true)
+            }
+            return Uri.fromFile(file)
+        } catch (e: Exception) {
+            return null
+        } finally {
+            runCatching { temp.delete() }
+        }
+    }
+
+    /** True when [uriString] is not already a local `file://` URI and should be copied. */
+    fun needsCopy(uriString: String?): Boolean {
+        if (uriString.isNullOrBlank()) return false
+        val scheme = Uri.parse(uriString).scheme
+        return scheme != null && scheme != "file"
+    }
+}

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -613,14 +613,27 @@ class MainViewModel @JvmOverloads constructor(
                 BackgroundPreferences(uri, enabled, alpha)
             }.collect { backgroundPrefs ->
                 if (!uiSurfaceAlphaPreviewDirty) {
+                    // No drag in progress: keep the preview and the persisted value in
+                    // sync (this also restores the preview after an interrupted drag via
+                    // syncUiSurfaceAlphaPreview()).
                     _uiSurfaceAlphaPreview.value = backgroundPrefs.alpha
-                }
-                _uiState.update {
-                    it.copy(
-                        customBackgroundUri = backgroundPrefs.uri,
-                        backgroundImageEnabled = backgroundPrefs.enabled,
-                        uiSurfaceAlpha = backgroundPrefs.alpha
-                    )
+                    _uiState.update {
+                        it.copy(
+                            customBackgroundUri = backgroundPrefs.uri,
+                            backgroundImageEnabled = backgroundPrefs.enabled,
+                            uiSurfaceAlpha = backgroundPrefs.alpha,
+                        )
+                    }
+                } else {
+                    // Drag in progress: a late DataStore emission from an earlier commit
+                    // must not yank the slider thumb back or override the live preview,
+                    // but background URI/enabled still need to keep up.
+                    _uiState.update {
+                        it.copy(
+                            customBackgroundUri = backgroundPrefs.uri,
+                            backgroundImageEnabled = backgroundPrefs.enabled,
+                        )
+                    }
                 }
             }
         }
@@ -3300,6 +3313,17 @@ class MainViewModel @JvmOverloads constructor(
     fun setUiSurfaceAlphaPreview(alpha: Float) {
         uiSurfaceAlphaPreviewDirty = true
         _uiSurfaceAlphaPreview.value = alpha.coerceIn(0f, 1f)
+    }
+
+    /**
+     * Resets the drag-preview state so the in-memory alpha re-syncs from the persisted
+     * value. Called when the settings page is disposed: an interrupted drag never fires
+     * Slider.onValueChangeFinished, which would otherwise leave the preview stuck on an
+     * un-persisted value for the rest of the session.
+     */
+    fun syncUiSurfaceAlphaPreview() {
+        uiSurfaceAlphaPreviewDirty = false
+        viewModelScope.launch { _uiSurfaceAlphaPreview.value = prefs.uiSurfaceAlpha.first() }
     }
     fun setBlurEnabled(v: Boolean) = viewModelScope.launch {
         prefs.setBlurEnabled(v)

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -24,6 +24,7 @@ import com.abk.kernel.data.repository.GitHubRepository
 import com.abk.kernel.data.repository.PreferencesRepository
 import com.abk.kernel.data.repository.Result
 import com.abk.kernel.ui.blur.BlurConfig
+import com.abk.kernel.utils.BackgroundImageStorage
 import com.abk.kernel.utils.BuildMonitorService
 import com.abk.kernel.utils.BuildProgressUtils
 import com.abk.kernel.utils.buildDisplaySnapshot
@@ -497,9 +498,30 @@ class MainViewModel @JvmOverloads constructor(
             str = { resId, args -> text(resId, *args) },
         )
         observePreferences()
+        migrateBackgroundUriToInternalStorage()
         observeForegroundWorkflowRefresh()
         if (registerStatusBroadcast) {
             registerStatusReceiver()
+        }
+    }
+
+    /**
+     * One-time migration: older installs persisted the picker's `content://` URI. Copy it
+     * into app-private storage so cold starts decode a local file instead of a cold content
+     * provider (slow wallpaper / black flash after the app is killed and reopened). Runs
+     * only while the stored URI is not already a local file.
+     */
+    private fun migrateBackgroundUriToInternalStorage() {
+        viewModelScope.launch {
+            val uriString = prefs.customBackgroundUri.first() ?: return@launch
+            if (!BackgroundImageStorage.needsCopy(uriString)) return@launch
+            val fileUri = withContext(Dispatchers.IO) {
+                BackgroundImageStorage.copyToInternalStorage(getApplication(), Uri.parse(uriString))
+            } ?: return@launch
+            // Only swap if the user has not picked a different background meanwhile.
+            if (prefs.customBackgroundUri.first() == uriString) {
+                prefs.setBackgroundImageUri(fileUri.toString())
+            }
         }
     }
 
@@ -3301,7 +3323,24 @@ class MainViewModel @JvmOverloads constructor(
     fun setCustomThemeColors(themeColorArgb: Int, accentColorArgb: Int) = viewModelScope.launch {
         prefs.setCustomThemeColors(themeColorArgb, accentColorArgb)
     }
-    fun setBackgroundImageUri(uri: String?) = viewModelScope.launch { prefs.setBackgroundImageUri(uri) }
+    /**
+     * Persists the picked background. `content://` picker URIs are first copied into
+     * app-private storage ([BackgroundImageStorage]) so cold starts decode a local file
+     * instead of a (possibly cold) content provider — otherwise the wallpaper can arrive
+     * late / the screen stays black after the app is killed and reopened. Runs in the
+     * view model scope so an early navigation away from the settings screen cannot cancel
+     * the copy. Falls back to the original URI when the copy fails.
+     */
+    fun setBackgroundImageUri(uri: String?) = viewModelScope.launch {
+        val storedUri = if (uri != null && BackgroundImageStorage.needsCopy(uri)) {
+            withContext(Dispatchers.IO) {
+                BackgroundImageStorage.copyToInternalStorage(getApplication(), Uri.parse(uri))
+            }?.toString() ?: uri
+        } else {
+            uri
+        }
+        prefs.setBackgroundImageUri(storedUri)
+    }
     fun setBackgroundImageEnabled(v: Boolean) = viewModelScope.launch { prefs.setBackgroundImageEnabled(v) }
     fun setUiSurfaceAlpha(alpha: Float) {
         val normalized = alpha.coerceIn(0f, 1f)

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -2045,6 +2045,10 @@ class MainViewModel @JvmOverloads constructor(
             override fun onStop(owner: LifecycleOwner) {
                 appInForeground = false
                 stopForegroundWorkflowRefresh()
+                // Backgrounding (Home / recents) mid-drag never fires the slider's
+                // onValueChangeFinished, so drop the un-persisted preview and restore the
+                // persisted alpha instead of leaving the whole app on a stale value.
+                syncUiSurfaceAlphaPreview()
             }
         })
         viewModelScope.launch {
@@ -3317,13 +3321,19 @@ class MainViewModel @JvmOverloads constructor(
 
     /**
      * Resets the drag-preview state so the in-memory alpha re-syncs from the persisted
-     * value. Called when the settings page is disposed: an interrupted drag never fires
-     * Slider.onValueChangeFinished, which would otherwise leave the preview stuck on an
-     * un-persisted value for the rest of the session.
+     * value. Called when the settings page is disposed or the app is backgrounded: an
+     * interrupted drag never fires Slider.onValueChangeFinished, which would otherwise
+     * leave the preview stuck on an un-persisted value for the rest of the session.
      */
     fun syncUiSurfaceAlphaPreview() {
         uiSurfaceAlphaPreviewDirty = false
-        viewModelScope.launch { _uiSurfaceAlphaPreview.value = prefs.uiSurfaceAlpha.first() }
+        viewModelScope.launch {
+            val persisted = prefs.uiSurfaceAlpha.first()
+            // Re-check: a new drag may have started while the read was in flight.
+            if (!uiSurfaceAlphaPreviewDirty) {
+                _uiSurfaceAlphaPreview.value = persisted
+            }
+        }
     }
     fun setBlurEnabled(v: Boolean) = viewModelScope.launch {
         prefs.setBlurEnabled(v)

--- a/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/abk/kernel/viewmodel/MainViewModel.kt
@@ -23,6 +23,7 @@ import com.abk.kernel.data.model.*
 import com.abk.kernel.data.repository.GitHubRepository
 import com.abk.kernel.data.repository.PreferencesRepository
 import com.abk.kernel.data.repository.Result
+import com.abk.kernel.ui.blur.BlurConfig
 import com.abk.kernel.utils.BuildMonitorService
 import com.abk.kernel.utils.BuildProgressUtils
 import com.abk.kernel.utils.buildDisplaySnapshot
@@ -205,6 +206,8 @@ data class MainUiState(
     val customBackgroundUri: String? = null,
     val backgroundImageEnabled: Boolean = false,
     val uiSurfaceAlpha: Float = 1f,
+    val blurEnabled: Boolean = true,
+    val blurBackgroundExpEnabled: Boolean = false,
     val downloadDirectory: String = DownloadDirectoryUtils.defaultDirectoryPath(),
     val downloadMirrorBaseUrl: String = "",
     val prebuiltGkiEnabled: Boolean = true,
@@ -271,6 +274,15 @@ data class MainUiState(
 ) {
     val isDownloading: Boolean
         get() = activeDownloadTasks.isNotEmpty() || downloadProgress.isNotEmpty()
+
+    /** Blur preferences snapshot for [BlurScreenScaffold]. */
+    val blurConfig: BlurConfig
+        get() = BlurConfig(
+            blurEnabled = blurEnabled,
+            backgroundExpEnabled = blurBackgroundExpEnabled,
+            backgroundUri = customBackgroundUri,
+            backgroundImageEnabled = backgroundImageEnabled,
+        )
 }
 
 class MainViewModel @JvmOverloads constructor(
@@ -321,6 +333,10 @@ class MainViewModel @JvmOverloads constructor(
 
     private val _uiState = MutableStateFlow(MainUiState())
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
+    private val _uiSurfaceAlphaPreview = MutableStateFlow(1f)
+    val uiSurfaceAlphaPreview: StateFlow<Float> = _uiSurfaceAlphaPreview.asStateFlow()
+    private var uiSurfaceAlphaPreviewDirty = false
 
     private fun text(@StringRes resId: Int, vararg args: Any): String =
         LocaleHelper.str(resId, *args)
@@ -596,6 +612,9 @@ class MainViewModel @JvmOverloads constructor(
             ) { uri, enabled, alpha ->
                 BackgroundPreferences(uri, enabled, alpha)
             }.collect { backgroundPrefs ->
+                if (!uiSurfaceAlphaPreviewDirty) {
+                    _uiSurfaceAlphaPreview.value = backgroundPrefs.alpha
+                }
                 _uiState.update {
                     it.copy(
                         customBackgroundUri = backgroundPrefs.uri,
@@ -603,6 +622,16 @@ class MainViewModel @JvmOverloads constructor(
                         uiSurfaceAlpha = backgroundPrefs.alpha
                     )
                 }
+            }
+        }
+        viewModelScope.launch {
+            prefs.blurEnabled.collect { enabled ->
+                _uiState.update { it.copy(blurEnabled = enabled) }
+            }
+        }
+        viewModelScope.launch {
+            prefs.blurBackgroundExpEnabled.collect { enabled ->
+                _uiState.update { it.copy(blurBackgroundExpEnabled = enabled) }
             }
         }
         viewModelScope.launch {
@@ -939,6 +968,8 @@ class MainViewModel @JvmOverloads constructor(
                     customBackgroundUri = it.customBackgroundUri,
                     backgroundImageEnabled = it.backgroundImageEnabled,
                     uiSurfaceAlpha = it.uiSurfaceAlpha,
+                    blurEnabled = it.blurEnabled,
+                    blurBackgroundExpEnabled = it.blurBackgroundExpEnabled,
                     downloadDirectory = it.downloadDirectory,
                     downloadMirrorBaseUrl = it.downloadMirrorBaseUrl,
                     prebuiltGkiEnabled = it.prebuiltGkiEnabled,
@@ -3255,7 +3286,27 @@ class MainViewModel @JvmOverloads constructor(
     }
     fun setBackgroundImageUri(uri: String?) = viewModelScope.launch { prefs.setBackgroundImageUri(uri) }
     fun setBackgroundImageEnabled(v: Boolean) = viewModelScope.launch { prefs.setBackgroundImageEnabled(v) }
-    fun setUiSurfaceAlpha(alpha: Float) = viewModelScope.launch { prefs.setUiSurfaceAlpha(alpha) }
+    fun setUiSurfaceAlpha(alpha: Float) {
+        val normalized = alpha.coerceIn(0f, 1f)
+        uiSurfaceAlphaPreviewDirty = false
+        _uiSurfaceAlphaPreview.value = normalized
+        viewModelScope.launch { prefs.setUiSurfaceAlpha(normalized) }
+    }
+
+    /**
+     * In-memory preview while the slider is being dragged. Persisted on drag end via
+     * [setUiSurfaceAlpha]; no DataStore write happens per drag tick.
+     */
+    fun setUiSurfaceAlphaPreview(alpha: Float) {
+        uiSurfaceAlphaPreviewDirty = true
+        _uiSurfaceAlphaPreview.value = alpha.coerceIn(0f, 1f)
+    }
+    fun setBlurEnabled(v: Boolean) = viewModelScope.launch {
+        prefs.setBlurEnabled(v)
+    }
+    fun setBlurBackgroundExpEnabled(v: Boolean) = viewModelScope.launch {
+        prefs.setBlurBackgroundExpEnabled(v)
+    }
     fun acceptTerms() = viewModelScope.launch { prefs.acceptCurrentTerms() }
     suspend fun loadFlashFilterJson(): String? = prefs.flashFilterJson.first()
     fun saveFlashFilterJson(json: String) = viewModelScope.launch { prefs.saveFlashFilterJson(json) }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -677,6 +677,10 @@
     <string name="settings_remove_background_desc">Restore the solid Material theme background</string>
     <string name="settings_ui_opacity">UI opacity</string>
     <string name="settings_ui_opacity_desc">Lower values let cards, top bars, and bottom bars reveal the background.</string>
+    <string name="settings_blur">Blur</string>
+    <string name="settings_blur_desc">Enable frosted-glass on top and bottom bars</string>
+    <string name="settings_blur_background">Render custom background into blur</string>
+    <string name="settings_blur_background_desc">When enabled, top bars, bottom bars, cards, and tiles blur the custom background image</string>
     <string name="settings_current_color">Current</string>
     <string name="settings_color_green">Green</string>
     <string name="settings_color_blue">Blue</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -678,7 +678,7 @@
     <string name="settings_ui_opacity">UI opacity</string>
     <string name="settings_ui_opacity_desc">Lower values let cards, top bars, and bottom bars reveal the background.</string>
     <string name="settings_blur">Blur</string>
-    <string name="settings_blur_desc">Enable frosted-glass on top and bottom bars</string>
+    <string name="settings_blur_desc">Enable frosted-glass blur effects</string>
     <string name="settings_blur_background">Render custom background into blur</string>
     <string name="settings_blur_background_desc">When enabled, top bars, bottom bars, cards, and tiles blur the custom background image</string>
     <string name="settings_current_color">Current</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -678,7 +678,7 @@
     <string name="settings_ui_opacity">Непрозрачность интерфейса</string>
     <string name="settings_ui_opacity_desc">При уменьшении карточки, верхняя и нижняя панели начинают пропускать фон.</string>
     <string name="settings_blur">Размытие</string>
-    <string name="settings_blur_desc">Включить матовое стекло на верхней и нижней панелях</string>
+    <string name="settings_blur_desc">Включить эффекты матового стекла</string>
     <string name="settings_blur_background">Рендерить пользовательский фон в размытие</string>
     <string name="settings_blur_background_desc">При включении верхняя и нижняя панели, карточки и плитки размывают изображение пользовательского фона</string>
     <string name="settings_current_color">Текущий</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -677,6 +677,10 @@
     <string name="settings_remove_background_desc">Вернуться к сплошному фону темы Material</string>
     <string name="settings_ui_opacity">Непрозрачность интерфейса</string>
     <string name="settings_ui_opacity_desc">При уменьшении карточки, верхняя и нижняя панели начинают пропускать фон.</string>
+    <string name="settings_blur">Размытие</string>
+    <string name="settings_blur_desc">Включить матовое стекло на верхней и нижней панелях</string>
+    <string name="settings_blur_background">Рендерить пользовательский фон в размытие</string>
+    <string name="settings_blur_background_desc">При включении верхняя и нижняя панели, карточки и плитки размывают изображение пользовательского фона</string>
     <string name="settings_current_color">Текущий</string>
     <string name="settings_color_green">Зелёный</string>
     <string name="settings_color_blue">Синий</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -708,7 +708,7 @@
     <string name="settings_ui_opacity">界面不透明度</string>
     <string name="settings_ui_opacity_desc">调低后卡片、顶部栏和底部栏会透出背景。</string>
     <string name="settings_blur">模糊</string>
-    <string name="settings_blur_desc">为顶部栏和底部栏启用毛玻璃效果</string>
+    <string name="settings_blur_desc">为界面启用毛玻璃模糊效果</string>
     <string name="settings_blur_background">将自定义背景渲染到模糊</string>
     <string name="settings_blur_background_desc">开启后，顶栏、底栏、卡片和磁贴会模糊自定义背景图片</string>
     <string name="settings_current_color">当前</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -707,6 +707,10 @@
     <string name="settings_remove_background_desc">恢复纯色 Material 主题背景</string>
     <string name="settings_ui_opacity">界面不透明度</string>
     <string name="settings_ui_opacity_desc">调低后卡片、顶部栏和底部栏会透出背景。</string>
+    <string name="settings_blur">模糊</string>
+    <string name="settings_blur_desc">为顶部栏和底部栏启用毛玻璃效果</string>
+    <string name="settings_blur_background">将自定义背景渲染到模糊</string>
+    <string name="settings_blur_background_desc">开启后，顶栏、底栏、卡片和磁贴会模糊自定义背景图片</string>
     <string name="settings_current_color">当前</string>
     <string name="settings_color_green">绿</string>
     <string name="settings_color_blue">蓝</string>

--- a/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
+++ b/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
@@ -1,0 +1,39 @@
+package com.abk.kernel.ui.blur
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BlurConfigTest {
+
+    private fun config(
+        blurEnabled: Boolean = true,
+        backgroundExpEnabled: Boolean = true,
+        backgroundUri: String? = "content://custom-background",
+        backgroundImageEnabled: Boolean = true,
+    ) = BlurConfig(
+        blurEnabled = blurEnabled,
+        backgroundExpEnabled = backgroundExpEnabled,
+        backgroundUri = backgroundUri,
+        backgroundImageEnabled = backgroundImageEnabled,
+    )
+
+    @Test
+    fun wantsBackgroundPainterRequiresAllFlags() {
+        val base = config()
+        assertTrue(base.wantsBackgroundPainter)
+
+        assertFalse(config(blurEnabled = false).wantsBackgroundPainter)
+        assertFalse(config(backgroundExpEnabled = false).wantsBackgroundPainter)
+        assertFalse(config(backgroundUri = null).wantsBackgroundPainter)
+        assertFalse(config(backgroundUri = "").wantsBackgroundPainter)
+        assertFalse(config(backgroundUri = "   ").wantsBackgroundPainter)
+        assertFalse(config(backgroundImageEnabled = false).wantsBackgroundPainter)
+    }
+
+    @Test
+    fun masterSwitchOffDisablesNestedBackgroundPainter() {
+        // Even if the nested flag is still persisted, the master switch must win.
+        assertFalse(config(blurEnabled = false, backgroundExpEnabled = true).wantsBackgroundPainter)
+    }
+}

--- a/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
+++ b/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
@@ -19,11 +19,12 @@ class BlurConfigTest {
     )
 
     @Test
-    fun wantsBackgroundPainterRequiresAllFlags() {
+    fun wantsBackgroundPainterRequiresBackgroundFlags() {
         val base = config()
         assertTrue(base.wantsBackgroundPainter)
 
-        assertFalse(config(blurEnabled = false).wantsBackgroundPainter)
+        // The master AGSL bar-blur switch must NOT gate the software card-blur path.
+        assertTrue(config(blurEnabled = false).wantsBackgroundPainter)
         assertFalse(config(backgroundExpEnabled = false).wantsBackgroundPainter)
         assertFalse(config(backgroundUri = null).wantsBackgroundPainter)
         assertFalse(config(backgroundUri = "").wantsBackgroundPainter)
@@ -32,8 +33,9 @@ class BlurConfigTest {
     }
 
     @Test
-    fun masterSwitchOffDisablesNestedBackgroundPainter() {
-        // Even if the nested flag is still persisted, the master switch must win.
-        assertFalse(config(blurEnabled = false, backgroundExpEnabled = true).wantsBackgroundPainter)
+    fun masterSwitchDoesNotGateSoftwareCardBlur() {
+        // The software StackBlur path is independent of the AGSL bar-blur master switch,
+        // so a disabled master switch must not disable the card blur.
+        assertTrue(config(blurEnabled = false, backgroundExpEnabled = true).wantsBackgroundPainter)
     }
 }

--- a/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
+++ b/app/src/test/java/com/abk/kernel/ui/blur/BlurConfigTest.kt
@@ -19,12 +19,11 @@ class BlurConfigTest {
     )
 
     @Test
-    fun wantsBackgroundPainterRequiresBackgroundFlags() {
+    fun wantsBackgroundPainterRequiresAllFlags() {
         val base = config()
         assertTrue(base.wantsBackgroundPainter)
 
-        // The master AGSL bar-blur switch must NOT gate the software card-blur path.
-        assertTrue(config(blurEnabled = false).wantsBackgroundPainter)
+        assertFalse(config(blurEnabled = false).wantsBackgroundPainter)
         assertFalse(config(backgroundExpEnabled = false).wantsBackgroundPainter)
         assertFalse(config(backgroundUri = null).wantsBackgroundPainter)
         assertFalse(config(backgroundUri = "").wantsBackgroundPainter)
@@ -33,9 +32,8 @@ class BlurConfigTest {
     }
 
     @Test
-    fun masterSwitchDoesNotGateSoftwareCardBlur() {
-        // The software StackBlur path is independent of the AGSL bar-blur master switch,
-        // so a disabled master switch must not disable the card blur.
-        assertTrue(config(blurEnabled = false, backgroundExpEnabled = true).wantsBackgroundPainter)
+    fun masterSwitchOffDisablesNestedBackgroundPainter() {
+        // Even if the nested flag is still persisted, the master switch must win.
+        assertFalse(config(blurEnabled = false, backgroundExpEnabled = true).wantsBackgroundPainter)
     }
 }

--- a/app_dev/build.gradle.kts
+++ b/app_dev/build.gradle.kts
@@ -201,6 +201,9 @@ dependencies {
     // Preferences
     implementation(libs.datastore.preferences)
 
+    // Blur / glass
+    implementation(libs.miuix.blur)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ gson = "2.11.0"
 robolectric = "4.14.1"
 coroutines = "1.10.2"
 androidxTestCore = "1.6.1"
+miuix = "0.9.2"
 nanohttpd = "2.3.1"
 
 [libraries]
@@ -60,6 +61,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+miuix-blur = { group = "top.yukonga.miuix.kmp", name = "miuix-blur-android", version.ref = "miuix" }
 nanohttpd = { group = "org.nanohttpd", name = "nanohttpd", version.ref = "nanohttpd" }
 
 [plugins]


### PR DESCRIPTION
## Summary

Ports **Miuix blur** (frosted-glass top / bottom bars) into the Expressive UI and adds an optional **custom-background card/tile blur** (frosted cards over the wallpaper), including a software fallback for pre-API-33 devices.

## What's included

**1. Miuix blur for the app chrome** (`ui/blur/` — `BlurBackdrop`, `BlurHost`, `BlurState`, `BlurScreenScaffold`, `BlurBackgroundPainter`)

- ~20 screens migrated from `Scaffold` to `BlurScreenScaffold`.
- The master blur switch is shown on **all** devices and is decoupled from device capability: the software card-blur path does not require runtime shaders, so it works on API 26-32 too.

**2. Custom card/tile backdrop blur** (`BlurredCardBackdrop.kt`)

- The custom background is pre-blurred once (downsampled 4x, StackBlur radius 45) and the matching sub-rect is drawn under each frosted card.
- Uses a software StackBlur fallback on pre-API-33 devices (no `RuntimeShader` dependency).

## Design decisions (and how prior review concerns are addressed)

- **minSdk-33 AAR on an API-26 app** (`tools:overrideLibrary` in the manifest): every path into the library is gated on `isRuntimeShaderSupported()` (API 33+), and the AAR registers no `ContentProvider` / initializer, so nothing library-side executes on API 26-32. This is documented in the manifest comment.
- **Decode sizing**: the shared wallpaper painter is sized to the display (`ImageRequest.size(displayMetrics)`), and the card-blur decode is constrained to `viewport/4` (`ImageRequest.size(...)`) with `allowHardware(false)` — never a full-resolution decode.
- **Memory / bitmaps**: blur runs on `Dispatchers.Default`; the JPEG cache write runs on `Dispatchers.IO`; intermediate bitmaps are recycled; `ContentScale.Crop` is applied everywhere.
- **On-disk blur cache**: keyed by `SHA-256(uri)` (collision-resistant, not `hashCode()`), with a version + radius + downsample component so a future algorithm change cannot silently reuse stale data. Entries are **count-pruned** (keep 4 newest) rather than deleted on switch, so toggling between wallpapers reuses the cache. Corrupt files are deleted on decode failure; orphaned `.tmp` files are pruned on save.
- **Viewport resize**: the anchor size is mirrored into snapshot state (`LocalBlurBackgroundSize`, because `LayoutCoordinates.size` is not observable). Re-blur is driven by a **coverage check** — the cached bitmap is re-blurred only when the viewport grows past it (rotation, split-screen, freeform taller, fold unfold), and skipped for shrink-only changes (IME), where the taller bitmap still samples the correct region. This avoids both stale-stretched backdrops and per-keypress re-blurs.
- **IME handling**: `windowSoftInputMode="adjustResize"` (matches `dev`), so the keyboard never covers content on Android 11+; the coverage check ensures an IME height change does not re-run the blur.
- **No first-frame flash**: `LocalBlurredCardBackgroundEnabled` is a synchronous signal, so cards stay translucent from the first frame instead of flashing opaque→translucent when the frosted backdrop arrives.

## Testing

- `BlurConfigTest` unit-tests the blur config → enabled-state mapping.
- The resize / IME / cache-reuse paths are exercised on the emulator and a physical API-26 device (software fallback).
