### PR TITLE
fix(ci): checkout repo before validating custom-source inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,6 +444,24 @@ jobs:
           fi
           exit 1
 
+      - name: 清理磁盘空间
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
+          rm_cmd: "rmz"
+          rmz_version: "3.1.1"
+          testing: false
+
+      - name: 检出代码仓库
+        uses: actions/checkout@v6
+
       - name: 校验类 LineageOS 源码构建参数
         if: inputs.source_mode == 'custom_git'
         env:
@@ -480,24 +498,6 @@ jobs:
           printf '%s\n' "$SOURCE_DEFCONFIGS" | grep -qx 'gki_defconfig' || {
             echo "::error::defconfig 列表必须包含 gki_defconfig"; exit 1;
           }
-
-      - name: 清理磁盘空间
-        uses: endersonmenezes/free-disk-space@v3
-        with:
-          remove_android: true
-          remove_dotnet: true
-          remove_haskell: true
-          remove_tool_cache: true
-          remove_swap: true
-          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
-          remove_packages_one_command: true
-          remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
-          rm_cmd: "rmz"
-          rmz_version: "3.1.1"
-          testing: false
-
-      - name: 检出代码仓库
-        uses: actions/checkout@v6
 
       - name: 确定 KernelSU 分支
         if: inputs.ksu_variant != 'None'


### PR DESCRIPTION
## Summary
- The "校验类 LineageOS 源码构建参数" step called `.github/scripts/custom-source.py`, but ran before `actions/checkout`, so the script didn't exist on the runner yet (`No such file or directory`).
- Moved `actions/checkout` (and the disk-cleanup step ahead of it) before the custom-source validation step so the repo/scripts are present when the step runs.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — YAML parses fine
- [x] Verified step order: 清理磁盘空间 → 检出代码仓库 → 校验类 LineageOS 源码构建参数 → 确定 KernelSU 分支 (unchanged downstream steps)
- [ ] Trigger `Android 内核构建-类 LineageOS 源码` workflow with a real Lineage-like source repo to confirm the validation step now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)