### PR TITLE
feat: add OrcaRouter as a named opencode provider

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "orcarouter": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OrcaRouter",
+      "options": {
+        "baseURL": "https://api.orcarouter.ai/v1",
+        "apiKey": "{env:ORCAROUTER_API_KEY}"
+      },
+      "models": {
+        "orcarouter/auto": {
+          "id": "orcarouter/auto",
+          "name": "OrcaRouter Auto (adaptive routing)"
+        },
+        "orcarouter/free": {
+          "id": "orcarouter/free",
+          "name": "OrcaRouter Free"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

ABK's `opencode.yml` workflow already brings the [opencode](https://opencode.ai) coding agent into this repository, so `/opencode` comments can be turned into actions. Today it is wired to a single hardcoded model (`opencode/deepseek-v4-flash-free`) that flows through opencode's own service, which means every ABK contributor using the opencode integration must hold an opencode account and key.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means ABK's opencode setup can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

## What

This adds a repo-root `opencode.json` registering **`orcarouter`** as a named opencode provider, mirroring how opencode's own config registers custom OpenAI-compatible providers (`@ai-sdk/openai-compatible` with a `baseURL` and `{env:...}` API key):

- `orcarouter/auto` — adaptive routing; OrcaRouter grades each prompt and picks the best/cheapest model per request.
- `orcarouter/free` — the free tier.

Because opencode reads a project-root `opencode.json` in the checked-out working tree, the existing `opencode.yml` workflow picks this provider up automatically. Switching the workflow's `model` input to `orcarouter/orcarouter/auto` is a one-line change; the `ORCAROUTER_API_KEY` secret can be added to the repository and passed through the workflow's existing `env:` block the same way `OPENCODE_API_KEY` is today.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `opencode run --model orcarouter/orcarouter/auto` against this repo's `opencode.json` resolves the provider and completes a real chat round-trip through `https://api.orcarouter.ai/v1/chat/completions` (HTTP 200).
- Both registered model IDs (`orcarouter/auto`, `orcarouter/free`) respond to the OpenAI-compatible Chat Completions endpoint.

No application code or existing workflow behavior is changed; this is purely additive configuration.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
